### PR TITLE
Backend prevent change end date before start date

### DIFF
--- a/backend/api/contest.ts
+++ b/backend/api/contest.ts
@@ -62,6 +62,15 @@ router.put('/contest',
       return
     }
     const settings = matchedData(req) as CompetitionSettings
+
+    const startDate = new Date(settings.start_date * 1000)
+    const endDate = new Date(settings.end_date * 1000)
+
+    if (endDate <= startDate) {
+      res.status(400).send({ message: "End date can not be before start date!" })
+      return
+    }
+
     contest.save_settings(settings)
       .then(_ => res.send(settings))
       .catch(err => res.status(400).send(err))

--- a/frontend/src/pages/admin/Settings.tsx
+++ b/frontend/src/pages/admin/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Button, Form, Input } from 'semantic-ui-react'
+import { Button, Form, Input, Message } from 'semantic-ui-react'
 import { Block } from '../../components'
 import config from '../../environment'
 
@@ -22,6 +22,7 @@ const Settings = (): JSX.Element => {
     points_per_compilation_error: '0',
     points_per_minute: '0'
   })
+  const [message, setMessage] = useState<{ type: string, message: string }>()
 
   useEffect(() => {
     fetch(`${config.API_URL}/contest`)
@@ -50,14 +51,23 @@ const Settings = (): JSX.Element => {
     formData.set('start_date', `${Date.parse(`${settings.start_date} ${settings.start_time}`) / 1000.0}`)
     formData.set('end_date', `${Date.parse(`${settings.end_date} ${settings.end_time}`) / 1000.0}`)
 
-    await fetch(`${config.API_URL}/contest`, {
+    const res = await fetch(`${config.API_URL}/contest`, {
       method: 'PUT',
       body: formData
     })
+
+    if (res.status == 200) {
+      setMessage({ type: 'success', message: "Settings saved successfully!" })
+    } else if (res.status == 400) {
+      const body = await res.json()
+      setMessage({ type: 'error', message: body.message })
+    }
   }
 
   return (
     <Block center size='xs-6'>
+      {message?.type == 'error' ? <Message error icon='warning' header='Error!' content={message.message} /> :
+        message?.type == 'success' ? <Message success icon='check' header='Saved!' content={message.message} /> : <></>}
       <Form onSubmit={handleSubmit}>
         <h1>Settings</h1>
         <hr />


### PR DESCRIPTION
# Description

This change stops admins from changing the end date to before the start date on a backend level. The frontend will now show errors (and success) when saving settings.

<img width="593" alt="Screen Shot 2021-02-21 at 11 40 47 PM" src="https://user-images.githubusercontent.com/6877893/108667216-51be1a80-749e-11eb-9e8d-3ec927906855.png">


Fixes #11 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
I tested this change by using Postman to send requests to the backend where the dates were reversed and received an error in response, no database change occurred. I also tried a valid date configuration and the database updated. I then proceeded to try these same tests through the user interface

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->