### PR TITLE
Fixed logic for clock before start date

### DIFF
--- a/frontend/src/components/Countdown.tsx
+++ b/frontend/src/components/Countdown.tsx
@@ -5,6 +5,7 @@ import { CompetitionSettings } from "../types";
 import config from '../environment'
 import { Block } from "./";
 import "./Countdown.scss";
+import FlipClock from "./FlipClock";
 
 const Countdown = (): JSX.Element => {
   const [settings, setSettings] = useState<CompetitionSettings>()
@@ -42,6 +43,13 @@ const Countdown = (): JSX.Element => {
       {isLoading || !settings ?
         <Loader active inline='centered' content="Loading" /> :
         <>
+        {time < settings.start_date ? 
+        <>
+        <h1>{settings?.competition_name}</h1>
+        <FlipClock count_to={settings.start_date} />
+        </> 
+        :
+        <>
           <div className="upper">
             <p>
               <b>Start</b> <Moment date={settings.start_date} format="MM/DD/YYYY, hh:mm:ss A" />
@@ -76,7 +84,7 @@ const Countdown = (): JSX.Element => {
             </p>
           </div>
         </>
-      }
+      } </> }
     </Block>
   );
 };


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed or feature request is implemented. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed flip clock not displaying for situations when the contest had not started.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

- [ ] 💡 New feature
<!-- Non-breaking change which adds functionality -->

- [ ] ⚠️ Breaking change
<!-- 
  - Changes a method signature.
  - Changes the behavior of a method.
  - Changes settings, configuration. -->

- [ ] 📚 Documentation Change
<!-- Changes to documentation only -->
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->