### PR TITLE
Use node instead of ts-node for prod start command

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,41 +1,41 @@
 {
-  "engines": {
-    "node": "12.16.1"
-  },
-  "scripts": {
-    "dev": "nodemon --exec ts-node --files src/server.ts",
-    "zip": "cp package.json dist/ && cd dist && zip -r backend .",
-    "build": "tsc",
-    "start": "ts-node src/server.ts"
-  },
-  "dependencies": {
-    "archiver": "^5.2.0",
-    "aws-sdk": "^2.833.0",
-    "body-parser": "^1.19.0",
-    "cors": "^2.8.5",
-    "crypto": "^1.0.1",
-    "express": "^4.17.1",
-    "express-fileupload": "^1.2.1",
-    "express-validator": "^6.9.2",
-    "jsonwebtoken": "^8.5.1",
-    "morgan": "^1.10.0",
-    "socket.io": "^3.1.1",
-    "uuid": "^3.3.2"
-  },
-  "devDependencies": {
-    "@types/archiver": "^5.1.0",
-    "@types/aws-sdk": "^2.7.0",
-    "@types/cors": "^2.8.9",
-    "@types/express": "^4.17.2",
-    "@types/express-fileupload": "^1.1.6",
-    "@types/express-validator": "^3.0.0",
-    "@types/jsonwebtoken": "^8.5.0",
-    "@types/morgan": "^1.9.2",
-    "@types/node": "^14.14.22",
-    "@types/uuid": "^8.3.0",
-    "dotenv": "^8.2.0",
-    "nodemon": "^2.0.7",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
-  }
+    "engines": {
+        "node": "12.16.1"
+    },
+    "scripts": {
+        "dev": "nodemon --exec ts-node --files src/server.ts",
+        "zip": "cp package.json dist/ && cd dist && zip -r backend .",
+        "build": "tsc",
+        "start": "node server.ts"
+    },
+    "dependencies": {
+        "archiver": "^5.2.0",
+        "aws-sdk": "^2.833.0",
+        "body-parser": "^1.19.0",
+        "cors": "^2.8.5",
+        "crypto": "^1.0.1",
+        "express": "^4.17.1",
+        "express-fileupload": "^1.2.1",
+        "express-validator": "^6.9.2",
+        "jsonwebtoken": "^8.5.1",
+        "morgan": "^1.10.0",
+        "socket.io": "^3.1.1",
+        "uuid": "^3.3.2"
+    },
+    "devDependencies": {
+        "@types/archiver": "^5.1.0",
+        "@types/aws-sdk": "^2.7.0",
+        "@types/cors": "^2.8.9",
+        "@types/express": "^4.17.2",
+        "@types/express-fileupload": "^1.1.6",
+        "@types/express-validator": "^3.0.0",
+        "@types/jsonwebtoken": "^8.5.0",
+        "@types/morgan": "^1.9.2",
+        "@types/node": "^14.14.22",
+        "@types/uuid": "^8.3.0",
+        "dotenv": "^8.2.0",
+        "nodemon": "^2.0.7",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.1.3"
+    }
 }


### PR DESCRIPTION
# Description
AWS backend was trying to ts-node src/server.js for prod environment. Src directory does not exist, and ts-node is not installed.

This fix uses node with the compiled source instead.

Fixes # (issue number)

## Type of change

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?
# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->