### PR TITLE
#39 Dont allow submissions before or after competition

### DIFF
--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -57,6 +57,16 @@ export const postSubmissions = async (req: Request, res: Response) => {
       return
     }
 
+    const settings = await contest.get_settings()
+    const now = Date.now()
+    if (now < settings.start_date * 1000) {
+      res.status(400).send('Competition has not started yet!')
+      return
+    } else if (now > settings.end_date * 1000) {
+      res.status(400).send('Competition has ended!')
+      return
+    }
+
     const submissions = await contest.scanItems('submission', { tid, pid })
 
     if (submissions) {


### PR DESCRIPTION
# Description

Send 400 status code when trying to submit to a problem before or after the competition.

Fixes #39 

## Type of change

- [x] 💡 New feature
<!-- Non-breaking change which adds functionality -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
Changed the competition around and tested sending a submission before, during, and after. The submission was only allowed to go through during the competition time.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->