### PR TITLE
File names for skeletons

### DIFF
--- a/backend/src/@types/abacus/index.d.ts
+++ b/backend/src/@types/abacus/index.d.ts
@@ -53,6 +53,7 @@ declare module "abacus" {
   export interface Skeleton {
     language: string;
     source: string;
+    file_name: string;
   }
   export interface ProblemScore {
     num_submissions: number;

--- a/backend/src/api/problems/postProblems.ts
+++ b/backend/src/api/problems/postProblems.ts
@@ -62,8 +62,11 @@ export const postProblems = async (req: Request, res: Response) => {
 
   const item = matchedData(req)
   item.pid = uuidv4().replace(/-/g, '')
-  item.skeletons = [{ source: '# Python skeleton goes here', language: 'python' }, { source: '// Java skeleton goes here', language: 'java' }]
-  item.solutions = [{ source: '# Python solution goes here', language: 'python' }, { source: '// Java solution goes here', language: 'java' }]
+
+  const filename = item.name.replace(/[ !@#$%^&*()-]/g, '')
+
+  item.skeletons = [{ source: '# Python skeleton goes here', file_name: `${filename}.py`, language: 'python' }, { source: '// Java skeleton goes here', file_name: `${filename}.py`, language: 'java' }]
+  item.solutions = [{ source: '# Python solution goes here', file_name: `${filename}.java`, language: 'python' }, { source: '// Java solution goes here', file_name: `${filename}.java`, language: 'java' }]
 
   const problems = await contest.scanItems('problem', { id: item.id }) || {}
   if (Object.values(problems).length > 0) {

--- a/frontend/src/pages/admin/problems/EditProblem.tsx
+++ b/frontend/src/pages/admin/problems/EditProblem.tsx
@@ -1,7 +1,7 @@
 import { Problem, Skeleton, Test } from 'abacus'
 import React, { ChangeEvent, MouseEvent, useState, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
-import { Form, Input, Menu, Button, TextArea, MenuItemProps, Message, Loader } from 'semantic-ui-react'
+import { Form, Input, Menu, Button, TextArea, MenuItemProps, Message, Loader, InputOnChangeData } from 'semantic-ui-react'
 import Editor from '@monaco-editor/react'
 import MDEditor from '@uiw/react-md-editor'
 import { Block } from 'components'
@@ -99,11 +99,26 @@ const Skeletons = ({ problem, setProblem }: ProblemStateProps) => {
   const handleSkeletonChange = (language: string, value?: string) => {
     if (problem && value)
       setProblem({
-        ...problem, skeletons: problem.skeletons?.map((skeleton: Skeleton) => {
-          if (language == skeleton.language)
-            skeleton.source = value
-          return skeleton
-        })
+        ...problem,
+        skeletons: problem.skeletons?.map((skeleton: Skeleton) =>
+          language == skeleton.language ? {
+            ...skeleton,
+            source: value
+          } : skeleton
+        )
+      })
+  }
+
+  const handleChange = (language: string, { value: file_name }: InputOnChangeData) => {
+    if (problem)
+      setProblem({
+        ...problem,
+        skeletons: problem.skeletons?.map((skeleton: Skeleton) =>
+          language == skeleton.language ? {
+            ...skeleton,
+            file_name
+          } : skeleton
+        )
       })
   }
 
@@ -113,21 +128,30 @@ const Skeletons = ({ problem, setProblem }: ProblemStateProps) => {
         <Menu.Item key={`skeleton-${index}`} name={skeleton.language} tab={skeleton.language} active={activeSkeleton == skeleton.language} onClick={handleSkeletonClick} />
       ))}
     </Menu>
-    {problem?.skeletons?.map((skeleton: Skeleton, index: number) => (
-      <div key={`editor=${index}`}>
-        {skeleton.language == activeSkeleton ?
-          <Editor
-            key={`editor-${index}`}
-            language={skeleton.language}
-            width="100%"
-            height="500px"
-            theme="vs"
-            value={skeleton.source}
-            options={{ minimap: { enabled: false } }}
-            onChange={(value?: string) => handleSkeletonChange(skeleton.language, value)}
-          /> : <></>}
-      </div>
-    ))}
+    {problem?.skeletons?.map((skeleton: Skeleton, index: number) =>
+      skeleton.language == activeSkeleton ?
+        <>
+          <div key={`editor=${index}`} style={{ margin: '15px 0' }}>
+            <Editor
+              key={`editor-${index}`}
+              language={skeleton.language}
+              width="100%"
+              height="500px"
+              theme="vs"
+              value={skeleton.source}
+              options={{ minimap: { enabled: false } }}
+              onChange={(value?: string) => handleSkeletonChange(skeleton.language, value)}
+            />
+          </div>
+          <Input
+            label='Filename'
+            size='small'
+            name='filename'
+            value={skeleton.file_name}
+            onChange={(event, data) => { handleChange(skeleton.language, data) }}
+            style={{ margin: '15px' }} />
+        </> : <></>
+    )}
   </>
 }
 

--- a/frontend/src/pages/admin/problems/NewProblem.tsx
+++ b/frontend/src/pages/admin/problems/NewProblem.tsx
@@ -140,7 +140,7 @@ const NewProblem = (): JSX.Element => {
         />
 
         <h1>Skeletons</h1>
-        <p>Skeletons will be auto generated.</p>
+        <p>Empty skeletons will be auto generated.</p>
         <Button primary onClick={handleSubmit}>Create</Button>
       </Block>
     </>

--- a/frontend/src/pages/admin/problems/Problems.tsx
+++ b/frontend/src/pages/admin/problems/Problems.tsx
@@ -70,7 +70,13 @@ const Problems = (): JSX.Element => {
     setLoading(false)
   }
 
-  const downloadProblems = () => saveAs(new File([JSON.stringify(problems, null, '\t')], 'problems.json', { type: 'text/json;charset=utf-8' }))
+  const downloadProblems = async () => {
+    const response = await fetch(`${config.API_URL}/problems?columns=description,skeletons,solutions,tests`)
+    if (response.ok) {
+      const problems = await response.json()
+      saveAs(new File([JSON.stringify(problems, null, '\t')], 'problems.json', { type: 'text/json;charset=utf-8' }))
+    }
+  }
   const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) => setProblems(problems.map(problem => problem.pid == id ? { ...problem, checked } : problem))
   const checkAll = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => setProblems(problems.map(problem => ({ ...problem, checked })))
 

--- a/frontend/src/pages/admin/submissions/Submission.tsx
+++ b/frontend/src/pages/admin/submissions/Submission.tsx
@@ -67,6 +67,9 @@ const submission = (): JSX.Element => {
     }
   }
 
+  const download = () => submission?.source &&
+    saveAs(new File([submission?.source], submission?.filename, { type: 'text/plain;charset=utf-8' }))
+
   const handleItemClick = (event: MouseEvent, data: MenuItemProps) => setActiveItem(data.tab)
   const handleTestItemClick = (event: MouseEvent, data: MenuItemProps) => setActiveTestItem(data.tab)
 
@@ -77,6 +80,7 @@ const submission = (): JSX.Element => {
   return <>
     <Block transparent size='xs-12' >
       <Button content="Rerun" icon="redo" labelPosition="left" onClick={rerun} />
+      <Button content="Download" icon="download" iconPosition="left" onClick={download} />
       <Button content="Delete" icon="trash" negative labelPosition="left" onClick={deleteSubmission} />
 
       <Table celled>

--- a/frontend/src/pages/admin/users/Users.tsx
+++ b/frontend/src/pages/admin/users/Users.tsx
@@ -60,7 +60,11 @@ const Users = (): JSX.Element => {
     }
   }
 
-  const downloadUsers = () => saveAs(new File([JSON.stringify(users, null, '\t')], 'users.json', { type: 'text/json;charset=utf-8' }))
+  const downloadUsers = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const sanitized = JSON.stringify(users.map(({ checked, ...user }) => user), null, '\t')
+    saveAs(new File([sanitized], 'users.json', { type: 'text/json;charset=utf-8' }))
+  }
   const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) => setUsers(users.map(user => user.uid == id ? { ...user, checked } : user))
   const checkAll = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => setUsers(users.map(user => ({ ...user, checked })))
 

--- a/frontend/src/pages/blue/practice/problem.json
+++ b/frontend/src/pages/blue/practice/problem.json
@@ -21,10 +21,12 @@
     ],
     "skeletons": [{
             "language": "python",
+            "file_name": "PracticeProblem.py",
             "source": "\ndef is_negative(x):\n    \"\"\"\n    TODO: Complete this function, which should return whether or not the input number is less than zero.\n\n    Parameters:\n    x --> (integer) the input number\n    \n    Returns:\n    result --> (boolean) True if x is less than zero, and False otherwise\n    \"\"\"\n    result = False\n\n    # write your code here to change \"result\"!\n\n    return result\n\n\n# It is unnecessary to edit the \"main\" function of each problem's provided code skeleton.\n# The main function is written for you in order to help you conform to input and output formatting requirements.\ndef main():\n    num_cases = int(input())\n\n    for _ in range(num_cases):\n        x = int(input())\n        x_is_negative = is_negative(x)\n\n        if x_is_negative:\n            print('Negative')\n        else:\n            print('Non-Negative')\n\nmain()\n    \n"
         },
         {
             "language": "java",
+            "file_name": "PracticeProblem.java",
             "source": "// Do NOT include a package statement at the top of your solution.\n\nimport java.util.Scanner;\n\npublic class PracticeProblem {\n\n    /*\n     * It is unnecessary to edit the \"main\" method of each problem's provided code skeleton.\n     * The main method is written for you in order to help you conform to input and output formatting requirements.\n     */\n    public static void main(String[] args) {\n        Scanner kb = new Scanner(System.in);\n        int numCases = kb.nextInt();\n        for (int iCase = 0; iCase < numCases; iCase++) {\n            int x = kb.nextInt();\n            boolean xIsNegative = isNegative(x);\n            if (xIsNegative) {\n                System.out.println(\"Negative\");\n            } else {\n                System.out.println(\"Non-Negative\");\n            }\n        }\n    }\n\n    public static boolean isNegative(int x) {\n        boolean result = false;\n\n        /*\n         * TODO: Write code that changes result to true if \"x\" is less than zero.\n         */ \n\n        return result;\n    }\n}"
         }
     ]

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -58,6 +58,7 @@ declare module "abacus" {
   export interface Skeleton {
     language: string;
     source: string;
+    file_name: string;
   }
   export interface ProblemScore {
     num_submissions: number;


### PR DESCRIPTION
# Description

* Adds `file_name` property to skeletons for download skeleton files
  * Particularly necessary for Java source files where class name and filename need to match
  * Filename defaults to problem name (without spaces or special characters) when creating new problems
* Remove `checked` from users when downloading as JSON
* Download all data about problems when downloading as JSON  
* Allow downloading submission's source code for local testing as a fallback.

Fixes #52

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
* Users.json includes checked property
<!-- Non-breaking change which fixes an issue -->

- [x] 💡 New feature
* Download all problem data when exporting
* Add download button for individual submissions
* `file_name` property for submissions
<!-- Non-breaking change which adds functionality -->

  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->