### PR TITLE
Release submissions (#50)

### DIFF
--- a/backend/src/@types/abacus/index.d.ts
+++ b/backend/src/@types/abacus/index.d.ts
@@ -19,7 +19,6 @@ declare module "abacus" {
     pid: string;
     runtime: number;
     released: boolean;
-    claimed?: string;
     score: number;
     status: string;
     sub_no: number;

--- a/backend/src/@types/abacus/index.d.ts
+++ b/backend/src/@types/abacus/index.d.ts
@@ -18,6 +18,8 @@ declare module "abacus" {
     md5: string;
     pid: string;
     runtime: number;
+    released: boolean;
+    claimed?: string;
     score: number;
     status: string;
     sub_no: number;

--- a/backend/src/api/submissions/getSubmissions.ts
+++ b/backend/src/api/submissions/getSubmissions.ts
@@ -1,3 +1,4 @@
+import { Test } from 'abacus'
 import { Request, Response } from 'express'
 import { matchedData, ParamSchema, validationResult } from "express-validator"
 import contest, { transpose } from '../../abacus/contest'
@@ -51,6 +52,17 @@ export const schema: Record<string, ParamSchema> = {
     notEmpty: true,
     optional: true,
     errorMessage: 'tid is invalid'
+  },
+  claimed: {
+    in: ['query', 'body'],
+    isString: true,
+    optional: true
+  },
+  released: {
+    in: ['query', 'body'],
+    isBoolean: true,
+    notEmpty: true,
+    optional: true
   }
 }
 
@@ -83,6 +95,11 @@ export const getSubmissions = async (req: Request, res: Response) => {
         display_name: team.display_name,
         division: team.division
       }
+      if (req.user?.role == 'team' && !submission.released) {
+        submission.status = 'pending'
+        submission.tests = submission.tests.map((test: Test) => ({ ...test, result: '' }))
+      }
+      return submission
     })
 
     res.send(transpose(submissions, 'sid'))

--- a/backend/src/api/submissions/getSubmissions.ts
+++ b/backend/src/api/submissions/getSubmissions.ts
@@ -53,11 +53,6 @@ export const schema: Record<string, ParamSchema> = {
     optional: true,
     errorMessage: 'tid is invalid'
   },
-  claimed: {
-    in: ['query', 'body'],
-    isString: true,
-    optional: true
-  },
   released: {
     in: ['query', 'body'],
     isBoolean: true,

--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -93,6 +93,8 @@ export const postSubmissions = async (req: Request, res: Response) => {
       filename,
       filesize,
       md5,
+      claimed: undefined,
+      released: false,
       sub_no: submissions?.length,
       status: 'pending',
       score: 0,

--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -93,7 +93,6 @@ export const postSubmissions = async (req: Request, res: Response) => {
       filename,
       filesize,
       md5,
-      claimed: undefined,
       released: false,
       sub_no: submissions?.length,
       status: 'pending',

--- a/backend/src/api/submissions/putSubmissions.ts
+++ b/backend/src/api/submissions/putSubmissions.ts
@@ -50,6 +50,16 @@ export const schema: Record<string, ParamSchema> = {
     notEmpty: true,
     optional: true,
     errorMessage: 'tid is invalid'
+  },
+  claimed: {
+    in: 'body',
+    isString: true,
+    optional: true
+  },
+  released: {
+    in: 'body',
+    isBoolean: true,
+    optional: true
   }
 }
 

--- a/backend/src/api/submissions/putSubmissions.ts
+++ b/backend/src/api/submissions/putSubmissions.ts
@@ -51,11 +51,6 @@ export const schema: Record<string, ParamSchema> = {
     optional: true,
     errorMessage: 'tid is invalid'
   },
-  claimed: {
-    in: 'body',
-    isString: true,
-    optional: true
-  },
   released: {
     in: 'body',
     isBoolean: true,

--- a/frontend/src/pages/admin/submissions/Submission.tsx
+++ b/frontend/src/pages/admin/submissions/Submission.tsx
@@ -77,7 +77,7 @@ const submission = (): JSX.Element => {
         Authorization: `Bearer ${localStorage.accessToken}`,
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ sid, released: true, claimed: undefined })
+      body: JSON.stringify({ sid, released: true })
     })
     if (response.ok) {
       const result = await response.json()

--- a/frontend/src/pages/admin/submissions/Submission.tsx
+++ b/frontend/src/pages/admin/submissions/Submission.tsx
@@ -15,6 +15,8 @@ const submission = (): JSX.Element => {
   const [submission, setSubmission] = useState<Submission>()
 
   const [isLoading, setLoading] = useState(true)
+  const [rerunning, setRerunning] = useState(false)
+  const [releaseLoading, setReleaseLoading] = useState(false)
 
   const [activeItem, setActiveItem] = useState('source-code')
   const [activeTestItem, setActiveTestItem] = useState(0)
@@ -49,6 +51,7 @@ const submission = (): JSX.Element => {
   }
 
   const rerun = async () => {
+    setRerunning(true)
     const response = await fetch(`${config.API_URL}/submissions/rerun`, {
       method: 'POST',
       headers: {
@@ -63,6 +66,24 @@ const submission = (): JSX.Element => {
         setSubmission({ team: submission?.team, problem: submission?.problem, ...result.submissions[sid] })
       }
     }
+    setRerunning(false)
+  }
+  const release = async () => {
+    if (!submission) return
+    setReleaseLoading(true)
+    const response = await fetch(`${config.API_URL}/submissions`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${localStorage.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ sid, released: true, claimed: undefined })
+    })
+    if (response.ok) {
+      const result = await response.json()
+      setSubmission({ ...submission, released: result.released })
+    }
+    setReleaseLoading(false)
   }
 
   const download = () => submission?.source &&
@@ -77,7 +98,11 @@ const submission = (): JSX.Element => {
 
   return <>
     <Block transparent size='xs-12' >
-      <Button content="Rerun" icon="redo" labelPosition="left" onClick={rerun} />
+      <Button disabled={rerunning} loading={rerunning} content="Rerun" icon="redo" labelPosition="left" onClick={rerun} />
+
+      {submission.released ?
+        <Button icon="check" positive content="Released" labelPosition="left" /> :
+        <Button loading={releaseLoading} disabled={releaseLoading} icon="right arrow" content="Release" labelPosition="left" onClick={release} />}
       <Button content="Download" icon="download" iconPosition="left" onClick={download} />
       <Button content="Delete" icon="trash" negative labelPosition="left" onClick={deleteSubmission} />
 
@@ -105,14 +130,16 @@ const submission = (): JSX.Element => {
             <Table.Cell>{submission.team.display_name}</Table.Cell>
             <Table.Cell><Moment fromNow date={submission?.date * 1000} /></Table.Cell>
             <Table.Cell><Link to={`/admin/problems/${submission.pid}`}>{submission.problem?.name}</Link></Table.Cell>
-            <Table.Cell><span className={`icn status ${submission.status}`} /></Table.Cell>
-            <Table.Cell>{Math.floor(submission.runtime)}</Table.Cell>
-            <Table.Cell>{submission.score}</Table.Cell>
+            <Table.Cell>
+              {rerunning ? <Loader inline size='small' active /> : <span className={`icn status ${submission.status}`} />}
+            </Table.Cell>
+            <Table.Cell>{rerunning ? <Loader active inline size='small' /> : Math.floor(submission.runtime)}</Table.Cell>
+            <Table.Cell>{rerunning ? <Loader active inline size='small' /> : submission.score}</Table.Cell>
             <Table.Cell>{submission.language}</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell colSpan={7}>
-              {submission?.tests.map((test: Test, index: number) => {
+              {rerunning ? <Loader inline size='small' active /> : submission?.tests.map((test: Test, index: number) => {
                 switch (test.result) {
                   case 'accepted':
                     return <span key={`test-${index}`} className='result icn accepted' />
@@ -165,33 +192,36 @@ const submission = (): JSX.Element => {
         </pre>
       </> :
         activeItem == 'test-cases' ? <div style={{ display: 'flex' }}>
-          <Menu secondary vertical>
-            {submission.tests.map((test: Test, index: number) =>
-              <Menu.Item key={`test-case-${index}`} name={`Test Case #${index + 1}`} active={activeTestItem === index} tab={index} onClick={handleTestItemClick} />
-            )}</Menu>
+          {rerunning ? <Loader active size='large' inline='centered' content="Retesting" /> :
+            <>
+              <Menu secondary vertical>
+                {submission.tests.map((test: Test, index: number) =>
+                  <Menu.Item key={`test-case-${index}`} name={`Test Case #${index + 1}`} active={activeTestItem === index} tab={index} onClick={handleTestItemClick} />
+                )}</Menu>
 
-          {submission.tests.map((test: Test, index: number) => (
-            <React.Fragment key={`test-result-${index}`}>
-              {index == activeTestItem ?
-                <div className='testRun'>
-                  <h3 className={test.result}>{capitalize(test.result || '')}</h3>
-                  <b>Input</b>
-                  <pre>{format_text(test.in)}</pre>
+              {submission.tests.map((test: Test, index: number) => (
+                <React.Fragment key={`test-result-${index}`}>
+                  {index == activeTestItem ?
+                    <div className='testRun'>
+                      <h3 className={test.result}>{capitalize(test.result || '')}</h3>
+                      <b>Input</b>
+                      <pre>{format_text(test.in)}</pre>
 
-                  <div>
-                    <div>
-                      <b>Output</b>
-                      <pre>{format_text(test.stdout || '')}</pre>
+                      <div>
+                        <div>
+                          <b>Output</b>
+                          <pre>{format_text(test.stdout || '')}</pre>
+                        </div>
+                        <div>
+                          <b>Expected</b>
+                          <pre>{format_text(test.out)}</pre>
+                        </div>
+                      </div>
                     </div>
-                    <div>
-                      <b>Expected</b>
-                      <pre>{format_text(test.out)}</pre>
-                    </div>
-                  </div>
-                </div>
-                : <></>}
-            </React.Fragment>
-          ))}
+                    : <></>}
+                </React.Fragment>
+              ))}
+            </>}
         </div>
           : <></>}
     </Block>

--- a/frontend/src/pages/blue/practice/Submit.tsx
+++ b/frontend/src/pages/blue/practice/Submit.tsx
@@ -94,6 +94,7 @@ const SubmitPractice = (): JSX.Element => {
         filesize,
         md5: '',
         sub_no: Object.values(submissions).filter(({ pid }: { pid: string }) => pid == id).length,
+        released: true,
         status: 'pending',
         score: 0,
         date: Date.now() / 1000,

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -20,6 +20,8 @@ declare module "abacus" {
     pid: string;
     problem: Problem;
     runtime: number;
+    released: boolean;
+    claimed?: string;
     score: number;
     status: string;
     sub_no: number;

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -21,7 +21,6 @@ declare module "abacus" {
     problem: Problem;
     runtime: number;
     released: boolean;
-    claimed?: string;
     score: number;
     status: string;
     sub_no: number;


### PR DESCRIPTION
# Description

- Submissions are unreleased (`released` = `false`) by default
- Team's submissions and submission view will not show results until submission is released

- New column in admin submissions view for released status
  - Table can filter out released submissions
- Submission view for admins has a release button to release results to the team. (Can't be unrelease)
  - Release button along with rerun now shows loader when waiting for network response

Fixes #50 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 💡 New feature
<!-- Non-breaking change which adds functionality -->

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->