### PR TITLE
Toggle released & Auto refresh for submissions

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -59,6 +59,7 @@ h6 {
     font-weight: normal;
 }
 
+
 /* header */
 
 .ui.fixed.menu.inverted {
@@ -82,6 +83,7 @@ h6 {
     height: 20px;
 }
 
+
 /* Block System */
 
 .ui.main.text.container {
@@ -91,6 +93,7 @@ h6 {
     flex-wrap: wrap;
     align-content: flex-start;
 }
+
 
 /* Stretch the navigation container, and the main container */
 
@@ -105,6 +108,7 @@ form#loginForm {
     flex-direction: column;
     align-items: center;
 }
+
 
 /* Button */
 
@@ -121,4 +125,9 @@ a.button {
 
 .ui.table thead th.sortable {
     cursor: pointer;
+}
+
+.ui.checkbox {
+    display: flex;
+    align-items: center;
 }

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -90,7 +90,6 @@ const Submissions = (): JSX.Element => {
       {submissions.filter(submission => submission.checked).length ?
         <Button content="Delete Submission(s)" negative onClick={deleteSelected} /> : <></>}
       <Checkbox toggle label="Show Released" checked={showReleased} onClick={onFilterChange} />
-      {/* <Button icon={showReleased ? 'eye' : 'eye slash'} color={showReleased ? "green" : undefined} content="Show Released" onClick={onFilterChange} /> */}
 
       <Table singleLine>
         <Table.Header>

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -1,6 +1,6 @@
 import { Submission } from 'abacus'
-import React, { ChangeEvent, useState, useEffect } from 'react'
-import { Button, Checkbox, CheckboxProps, Label, Loader, Table } from 'semantic-ui-react'
+import React, { ChangeEvent, useState, useEffect, useMemo } from 'react'
+import { Button, Checkbox, Label, Loader, Table } from 'semantic-ui-react'
 import Moment from 'react-moment'
 import { Link } from 'react-router-dom'
 import config from 'environment'
@@ -19,7 +19,7 @@ const Submissions = (): JSX.Element => {
   const [isLoading, setLoading] = useState<boolean>(true)
   const [submissions, setSubmissions] = useState<SubmissionItem[]>([])
   const [isMounted, setMounted] = useState<boolean>(true)
-  const [filterReleased, setFilterReleased] = useState(false)
+  const [showReleased, setShowReleased] = useState(false)
 
   const [{ column, direction }, setSortConfig] = useState<SortConfig>({
     column: 'date',
@@ -36,8 +36,12 @@ const Submissions = (): JSX.Element => {
   }
 
   useEffect(() => {
-    loadSubmissions()
-    return () => { setMounted(false) }
+    loadSubmissions().then(() => setLoading(false))
+    const timeInterval = setInterval(loadSubmissions, 5 * 1000)
+    return () => {
+      clearInterval(timeInterval)
+      setMounted(false)
+    }
   }, [])
 
   const loadSubmissions = async () => {
@@ -51,12 +55,9 @@ const Submissions = (): JSX.Element => {
     if (!isMounted) return
 
     setSubmissions(submissions.map(submission => ({ ...submission, checked: false })))
-    setLoading(false)
   }
 
-  const onFilterChange = (event: React.MouseEvent<HTMLInputElement, MouseEvent>, { checked }: CheckboxProps) => {
-    setFilterReleased(checked || false)
-  }
+  const onFilterChange = () => setShowReleased(!showReleased)
 
   const downloadSubmissions = () => saveAs(new File([JSON.stringify(submissions, null, '\t')], 'submissions.json', { type: 'text/json;charset=utf-8' }))
   const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) => setSubmissions(submissions.map(submission => submission.sid == id ? { ...submission, checked } : submission))
@@ -77,6 +78,10 @@ const Submissions = (): JSX.Element => {
     }
   }
 
+  const filteredSubmissions = useMemo(() =>
+    submissions.filter((submission) => showReleased || !submission.released)
+    , [submissions, showReleased])
+
   if (isLoading) return <Loader active inline='centered' content="Loading" />
 
   return (
@@ -84,7 +89,8 @@ const Submissions = (): JSX.Element => {
       <Button content="Download Submissions" onClick={downloadSubmissions} />
       {submissions.filter(submission => submission.checked).length ?
         <Button content="Delete Submission(s)" negative onClick={deleteSelected} /> : <></>}
-      <Checkbox toggle label="Hide Released" checked={filterReleased} onClick={onFilterChange} />
+      <Checkbox toggle label="Show Released" checked={showReleased} onClick={onFilterChange} />
+      {/* <Button icon={showReleased ? 'eye' : 'eye slash'} color={showReleased ? "green" : undefined} content="Show Released" onClick={onFilterChange} /> */}
 
       <Table singleLine>
         <Table.Header>
@@ -103,11 +109,11 @@ const Submissions = (): JSX.Element => {
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {submissions.length == 0 ?
+          {filteredSubmissions.length == 0 ?
             <Table.Row>
               <Table.Cell colSpan={10} style={{ textAlign: "center" }}>No Submissions</Table.Cell>
             </Table.Row> :
-            submissions.filter((submission) => !filterReleased || submission.released).map((submission) =>
+            filteredSubmissions.map((submission) =>
               <Table.Row key={submission.sid}>
                 <Table.Cell>
                   <input


### PR DESCRIPTION
# Description

- Fixes bug with toggle released on admin submissions page
- Auto refreshes submissions while on admin submissions page

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
Fixes Toggle to hide and show released submissions

- [x] 💡 New feature
Auto-refreshes submissions page for admins
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->