### PR TITLE
Fix a bug when creating public clarifications

### DIFF
--- a/backend/src/api/clarifications/postClarifications.ts
+++ b/backend/src/api/clarifications/postClarifications.ts
@@ -36,7 +36,8 @@ export const schema: Record<string, ParamSchema> = {
   context: {
     in: 'body',
     isObject: true,
-    notEmpty: true
+    notEmpty: true,
+    optional: true
   }
 }
 

--- a/backend/src/api/clarifications/putClarifications.ts
+++ b/backend/src/api/clarifications/putClarifications.ts
@@ -34,7 +34,8 @@ export const schema: Record<string, ParamSchema> = {
   context: {
     in: 'body',
     isObject: true,
-    notEmpty: true
+    notEmpty: true,
+    optional: true
   }
 }
 


### PR DESCRIPTION
# Description

When creating public clarifications, admins are presented with an invalid value error. This is because the backend requests a `context` to be provided. 

This PR will make `context` optional for clarifications.
<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!x- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->