### PR TITLE
Fixed TextArea height for TestData

### DIFF
--- a/frontend/src/components/editor/TestDataEditor.tsx
+++ b/frontend/src/components/editor/TestDataEditor.tsx
@@ -20,8 +20,7 @@ const TestDataEditor = ({ problem, setProblem }: ProblemStateProps): JSX.Element
     }
   }
 
-  const handleTestChange = ({ target: { name, value, style, scrollHeight } }: ChangeEvent<HTMLTextAreaElement>) => {
-    style.height = `${scrollHeight}px`
+  const handleTestChange = ({ target: { name, value } }: ChangeEvent<HTMLTextAreaElement>) =>
     setProblem({
       ...problem, tests: problem.tests?.map((test, index) => {
         if (name == `${index}-in`)
@@ -31,7 +30,6 @@ const TestDataEditor = ({ problem, setProblem }: ProblemStateProps): JSX.Element
         return test
       })
     })
-  }
 
   return <Form>
     <Menu>
@@ -48,8 +46,8 @@ const TestDataEditor = ({ problem, setProblem }: ProblemStateProps): JSX.Element
       <div key={`test-${index}`}>
         {activeTestItem == index ?
           <Form.Group widths='equal'>
-            <Form.Field style={{ height: '18em' }} label='Input' onChange={handleTestChange} control={TextArea} name={`${index}-in`} value={test.in} />
-            <Form.Field style={{ height: '18em' }} label='Answer' onChange={handleTestChange} control={TextArea} name={`${index}-out`} value={test.out} />
+            <Form.Field label='Input' onChange={handleTestChange} control={TextArea} rows={10} name={`${index}-in`} value={test.in} />
+            <Form.Field label='Answer' onChange={handleTestChange} control={TextArea} rows={10} name={`${index}-out`} value={test.out} />
           </Form.Group>
           : <></>}
       </div>


### PR DESCRIPTION
# Description

Set a fixed text area height with `rows={int}`. Rather than adjusting based on content which led to shrinking on character action

Fixes #134 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->