### PR TITLE
External Links should use <a> tags

### DIFF
--- a/frontend/src/components/ScratchViewer.tsx
+++ b/frontend/src/components/ScratchViewer.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import config from 'environment'
 import { Grid, Header, Icon, Label, Segment } from 'semantic-ui-react';
-import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import "./ScratchViewer.scss"
 

--- a/frontend/src/components/ScratchViewer.tsx
+++ b/frontend/src/components/ScratchViewer.tsx
@@ -55,7 +55,7 @@ const ScratchViewer = ({ project_id }: ScratchViewerProps): JSX.Element => {
 
       <Grid.Column className='scratch-info'>
         {project ? <Segment>
-          <Link to={`https://scratch.mit.edu/projects/${project_id}`}><h2>{project.title}</h2> {project.author.username}</Link>
+          <a target='_blank' rel='noreferrer' href={`https://scratch.mit.edu/projects/${project_id}`}><h2>{project.title}</h2> {project.author.username}</a>
           <p>{project.description}</p>
 
           <div className='history'>

--- a/frontend/src/pages/blue/Problem.tsx
+++ b/frontend/src/pages/blue/Problem.tsx
@@ -92,13 +92,13 @@ const problem = (): JSX.Element => {
         context={{ type: 'pid', id: problem.pid }}
         trigger={<Button content="Ask" icon="question" labelPosition='left' />}
       />
-      <Button
-        labelPosition='left'
-        as={Link}
-        to={`${config.API_URL}/sample_files?pid=${problem.pid}`}
-        content="Skeletons"
-        icon="download"
-      />
+      <a target='_blank' rel='noreferrer' href={`${config.API_URL}/sample_files?pid=${problem.pid}`}>
+        <Button
+          labelPosition='left'
+          content="Skeletons"
+          icon="download"
+        />
+      </a>
       {latestSubmission}
       <Divider />
       <p><b>Problem ID:</b> {problem.id}</p>


### PR DESCRIPTION
# Description

Fix links for scratch projects, and sample files. 

Use an `<a>` tag instead of `<Link>` tag for external links.

## Type of change

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->