### PR TITLE
Fix broken link for admin submission view

### DIFF
--- a/frontend/src/components/submission/SubmissionDetail.tsx
+++ b/frontend/src/components/submission/SubmissionDetail.tsx
@@ -20,7 +20,7 @@ const SubmissionDetail = (): JSX.Element => {
   const submission_link = <Table.Cell rowSpan={2}><Link to={`${user_home}/submissions/${submission.sid}`}>{submission.sid.substring(0, 7)}</Link></Table.Cell>
   const submission_team = <Table.Cell>{submission.team.display_name}</Table.Cell>
   const submission_date = <Table.Cell><Moment fromNow date={submission.date * 1000} /></Table.Cell>
-  const submission_problem = <Table.Cell><Link to={`${user_home}/problems/${submission.problem.id}`}>{submission.problem.name}</Link></Table.Cell>
+  const submission_problem = <Table.Cell><Link to={`${user_home}/problems/${user.role == 'admin' ? submission.problem.pid : submission.problem.id}`}>{submission.problem.name}</Link></Table.Cell>
 
   if (submission.division == 'blue') {
     return <Block transparent size='xs-12'>


### PR DESCRIPTION
# Description

Differentiate between roles for links to problems. Problem link's for teams use the short ID, but admins use the entire problem pid because short_ids can duplicate across divisions.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->