### PR TITLE
Fix resolving claimee for submissions & Bucket submissions correctly on judge home

### DIFF
--- a/backend/src/api/submissions/getSubmissions.ts
+++ b/backend/src/api/submissions/getSubmissions.ts
@@ -90,9 +90,14 @@ export const getSubmissions = async (req: Request, res: Response) => {
         display_name: team.display_name,
         division: team.division
       }
-      if (submission.claimed) {
+      if (submission.claimed !== undefined) {
         const claimee = users[submission.claimed]
-        submission.claimed = claimee
+        submission.claimed = {
+          uid: claimee.uid,
+          username: claimee.username,
+          display_name: claimee.display_name,
+          division: claimee.division
+        }
       }
       if (req.user?.role == 'team' && !submission.released) {
         submission.status = 'pending'

--- a/frontend/src/pages/judge/Home.tsx
+++ b/frontend/src/pages/judge/Home.tsx
@@ -18,7 +18,12 @@ const Home = (): JSX.Element => {
   const claimedSubmissions = useMemo(() => submissions?.filter(({ claimed }) => claimed !== undefined && claimed?.uid !== user?.uid), [submissions])
   const pendingSubmissions = useMemo(() => submissions?.filter(({ released }) => !released), [submissions])
   const recentSubmissions = useMemo(() => submissions?.filter(({ released }) => released).sort(({ date: date1 }, { date: date2 }) => date2 - date1), [submissions])
-  const myClaimedSubmissions = useMemo(() => submissions?.filter(submission => submission.claimed == user?.uid), [submissions])
+  const myClaimedSubmissions = useMemo(() => submissions?.filter(({ claimed }) => claimed?.uid == user?.uid), [submissions])
+
+  console.log(claimedSubmissions?.length)
+  console.log(pendingSubmissions?.length)
+  console.log(recentSubmissions?.length)
+  console.log(myClaimedSubmissions?.length)
 
   const loadData = async () => {
     const response = await fetch(`${config.API_URL}/submissions`, {


### PR DESCRIPTION
# Description

Fix a bug where claimed does not properly send to the frontend with user details, and properly bucket submissions in the right table on the judge homepage.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->