### PR TITLE
Only delete submissions if they are checked and visible (#147)

### DIFF
--- a/backend/src/api/submissions/deleteSubmissions.ts
+++ b/backend/src/api/submissions/deleteSubmissions.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { ParamSchema, validationResult } from "express-validator"
+import { io } from '../../server';
 import contest from '../../abacus/contest';
 
 export const schema: Record<string, ParamSchema> = {
@@ -23,6 +24,7 @@ export const deleteSubmissions = async (req: Request, res: Response) => {
       try {
         await contest.deleteItem('submission', { sid })
         success++
+        io.emit('delete_submission', { sid })
       } catch (err) {
         console.error(err)
         failed++
@@ -32,6 +34,9 @@ export const deleteSubmissions = async (req: Request, res: Response) => {
   } else {
     try {
       await contest.deleteItem('submission', { sid: req.body.sid })
+
+      io.emit('delete_submission', { sid: req.body.sid })
+
       res.json({ message: "Submission successfully deleted" })
     } catch (err) {
       console.error(err)

--- a/backend/src/api/submissions/getSubmissions.ts
+++ b/backend/src/api/submissions/getSubmissions.ts
@@ -85,18 +85,18 @@ export const getSubmissions = async (req: Request, res: Response) => {
       submission.problem = problems[submission.pid]
       const team = users[submission.tid]
       submission.team = {
-        uid: team.uid,
-        username: team.username,
-        display_name: team.display_name,
-        division: team.division
+        uid: team?.uid,
+        username: team?.username,
+        display_name: team?.display_name,
+        division: team?.division
       }
       if (submission.claimed !== undefined) {
         const claimee = users[submission.claimed]
         submission.claimed = {
-          uid: claimee.uid,
-          username: claimee.username,
-          display_name: claimee.display_name,
-          division: claimee.division
+          uid: claimee?.uid,
+          username: claimee?.username,
+          display_name: claimee?.display_name,
+          division: claimee?.division
         }
       }
       if (req.user?.role == 'team' && !submission.released) {

--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -145,7 +145,7 @@ export const postSubmissions = async (req: Request, res: Response) => {
 
     await contest.putItem('submission', submission)
 
-    io.emit('new_submission')
+    io.emit('new_submission', { sid: submission.sid })
 
     res.send(submission)
   } catch (err) {

--- a/backend/src/api/submissions/putSubmissions.ts
+++ b/backend/src/api/submissions/putSubmissions.ts
@@ -90,7 +90,7 @@ export const putSubmissions = async (req: Request, res: Response) => {
 
     if (item.released == true) notifyTeam(item)
 
-    io.emit('update_submission')
+    io.emit('update_submission', { sid: item.sid })
 
     res.send(item)
   } catch (err) {

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -61,9 +61,14 @@ const Submissions = (): JSX.Element => {
 
   const onFilterChange = () => setShowReleased(!showReleased)
 
-  const downloadSubmissions = () => saveAs(new File([JSON.stringify(submissions, null, '\t')], 'submissions.json', { type: 'text/json;charset=utf-8' }))
-  const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) => setSubmissions(submissions.map(submission => submission.sid == id ? { ...submission, checked } : submission))
-  const checkAll = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => setSubmissions(submissions.map(submission => ({ ...submission, checked })))
+  const downloadSubmissions = () =>
+    saveAs(new File([JSON.stringify(submissions, null, '\t')], 'submissions.json', { type: 'text/json;charset=utf-8' }))
+
+  const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) =>
+    setSubmissions(submissions.map(submission => submission.sid == id ? { ...submission, checked } : submission))
+
+  const checkAll = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) =>
+    setSubmissions(submissions.map(submission => (showReleased || !submission.released) ? { ...submission, checked } : submission))
 
   const deleteSelected = async () => {
     setDeleting(true)

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -67,7 +67,7 @@ const Submissions = (): JSX.Element => {
 
   const deleteSelected = async () => {
     setDeleting(true)
-    const submissionsToDelete = submissions.filter(submission => submission.checked).map(submission => submission.sid)
+    const submissionsToDelete = submissions.filter(submission => submission.checked && (!submission.released || showReleased)).map(submission => submission.sid)
     const response = await fetch(`${config.API_URL}/submissions`, {
       method: 'DELETE',
       headers: {


### PR DESCRIPTION
# Description

* When using the check all button, only visible submissions are updated.
* When clicking delete selected, only include checked and visible submissions.

Fixes #147 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->