### PR TITLE
Refresh notification listener when user changes.

### DIFF
--- a/frontend/src/components/Notifications.tsx
+++ b/frontend/src/components/Notifications.tsx
@@ -1,5 +1,5 @@
 import { Context, Notification } from 'abacus';
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { Message } from 'semantic-ui-react';
 import { v4 as uuidv4 } from 'uuid';
@@ -32,9 +32,11 @@ const Notifications = (): JSX.Element => {
 
   }
 
-  socket?.on('notification', (notification: Notification) => {
-    if (forMe(notification)) window.sendNotification(notification)
-  })
+  useEffect(() => {
+    socket?.on('notification', (notification: Notification) => {
+      if (forMe(notification)) window.sendNotification(notification)
+    })
+  }, [user])
 
   const forMe = ({ to }: Notification) => {
     if (!to || to == 'public') return true

--- a/frontend/src/components/Notifications.tsx
+++ b/frontend/src/components/Notifications.tsx
@@ -1,5 +1,5 @@
 import { Context, Notification } from 'abacus';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { Message } from 'semantic-ui-react';
 import { v4 as uuidv4 } from 'uuid';
@@ -32,11 +32,9 @@ const Notifications = (): JSX.Element => {
 
   }
 
-  useEffect(() => {
-    socket?.on('notification', (notification: Notification) => {
-      if (forMe(notification)) window.sendNotification(notification)
-    })
-  }, [])
+  socket?.on('notification', (notification: Notification) => {
+    if (forMe(notification)) window.sendNotification(notification)
+  })
 
   const forMe = ({ to }: Notification) => {
     if (!to || to == 'public') return true


### PR DESCRIPTION
# Description

When the notification listener is checking if the notification is for them, it does not refresh if the user state changes.

These changes refresh the listener when the user state changes.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->