### PR TITLE
Allow clients to broadcast messages

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,7 +5,7 @@ import express from "express";
 import fileUpload from 'express-fileupload';
 import { createServer } from 'http'
 import morgan from 'morgan';
-import { Server } from 'socket.io'
+import { Server, Socket } from 'socket.io'
 import { createAdapter } from 'socket.io-redis'
 import { RedisClient } from 'redis'
 import { v4 as uuidv4 } from 'uuid'
@@ -46,6 +46,12 @@ app.get('/', (_, res) => res.status(200).send(' ')); // Sends 200 OK when AWS EB
 
 export const sendNotification = ({ header, to, content, type, context }: Notification) =>
   io.sockets.emit('notification', ({ id: uuidv4(), to, header, content, type, context }))
+
+io.on('connection', (socket: Socket) => {
+  socket.on('broadcast', ({ ev, args }) => {
+    io.sockets.emit(ev, args)
+  })
+})
 
 server.listen(PORT, () => {
   console.log(`🚀 Server is running at :${PORT}`);


### PR DESCRIPTION
# Description

Allow clients to broadcast messages to other clients by implementing a boomerang broadcast handler in `server.ts` that will use the data to send a broadcast event to all clients.

Example use
`socket.emit('broadcast', {ev: 'EVENT_NAME', args: {EVENT_DATA}})`

This will allow the lambda function `PistonRunner` to broadcast `update_submission` after grading submissions.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 💡 New feature
<!-- Non-breaking change which adds functionality -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->