### PR TITLE
added ability for person making change to link to issue number

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!-- Please include a summary of the change and which issue is fixed or feature request is implemented. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
-Fixes # (issue number)
+Fixes issue #[Github issue number here](https://github.com/acm-mu/abacus/issues/187)
 
 ## Type of change
 


### PR DESCRIPTION
# Description 

- changes the pr template to include the ability to link directly to an issue
 
 Fixes #[187](https://github.com/acm-mu/abacus/issues/187) 
 
## Type of change
 - [x] 🐞 Bug fix
 - [x] 📚 Documentation Change
 
# How Has This Been Tested?
- By creating a github pr here and using the styling above.

- [x] Tested individually.