### PR TITLE
🧰 Prettier Fix

### DIFF
--- a/.github/workflows/ci-prettier.yml
+++ b/.github/workflows/ci-prettier.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
+    branches:
+      - '*'
+      - '!master'
 
 jobs:
   prettier:


### PR DESCRIPTION
# Description

DevOps Bug Fix. 

Prettier GitHub action cannot push to master because it is protected and requires peer reviews. Instead, run this action on every branch except master. By the time it a PR is created, prettier should have run.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->
  
# How Has This Been Tested?

This has not been tested, buyers beware!
