### PR TITLE
Add workflow to deploy Abacus backend to GHCR

### DIFF
--- a/.github/workflows/deploy-backend-docker.yml
+++ b/.github/workflows/deploy-backend-docker.yml
@@ -1,0 +1,40 @@
+name: Create and publish Abacus backend
+
+on:
+  push:
+    branches: ['master']
+    paths:
+      - 'backend/**'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: ghcr.io/acm-mu/abacus-backend
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: backend
+          file: backend/Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Description

Add a GitHub Workflow to build and push the production Docker image of the backend to the GitHub Container Registry.

## Type of change

- [X] Infrastructure
 