### PR TITLE
Socket io types

### DIFF
--- a/frontend/src/context/socket.ts
+++ b/frontend/src/context/socket.ts
@@ -1,6 +1,19 @@
+import { Submission, Notification } from 'abacus'
 import { createContext } from 'react'
 import { Socket } from 'socket.io-client'
 
-const SocketContext = createContext<Socket | undefined>(undefined)
+interface ClientToServerEvents {
+  notification: (notification: Notification)=> void;
+  new_submission: (submission: Submission) => void;
+  update_submission: (submission: Submission) => void;
+  delete_submission: (submission: Submission) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ServerToClientEvents  {
+
+}
+
+const SocketContext = createContext<Socket<ClientToServerEvents, ServerToClientEvents> | undefined>(undefined)
 
 export default SocketContext

--- a/frontend/src/context/socket.ts
+++ b/frontend/src/context/socket.ts
@@ -3,16 +3,14 @@ import { createContext } from 'react'
 import { Socket } from 'socket.io-client'
 
 interface ClientToServerEvents {
-  notification: (notification: Notification)=> void;
-  new_submission: (submission: Submission) => void;
-  update_submission: (submission: Submission) => void;
-  delete_submission: (submission: Submission) => void;
+  notification: (notification: Notification) => void
+  new_submission: (submission: Submission) => void
+  update_submission: (submission: Submission) => void
+  delete_submission: (submission: Submission) => void
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface ServerToClientEvents  {
-
-}
+interface ServerToClientEvents {}
 
 const SocketContext = createContext<Socket<ClientToServerEvents, ServerToClientEvents> | undefined>(undefined)
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,21 +1,21 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": true,
-        "noFallthroughCasesInSwitch": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "noEmit": true,
-        "jsx": "react-jsx",
-        "baseUrl": "src"
-    },
-    "include": ["src"]
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": "src"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
# Description

* Following Socket.io's [Migrating from 3.x to 4.0](https://socket.io/docs/v4/migrating-from-3-x-to-4-0/#typed-events) guide, defined client to server events on the frontend to conform to the socket io type definition.
* Upgraded tsconfig target to `es6` (`es5` does not have `class` keyword, which `Socket` is, so compilation error that `Socket` is not a type is because babel transpiles it down to a `function`)

Fixes #207 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
* Compiles to build, and runs locally

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->