### PR TITLE
🏷️ Add latest tag to docker GHCR deployments

### DIFF
--- a/.github/workflows/deploy-backend-docker.yml
+++ b/.github/workflows/deploy-backend-docker.yml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/metadata-action@v3.5.0
         with:
           images: ghcr.io/acm-mu/abacus-backend
+          tags: latest ${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2.7.0

--- a/.github/workflows/deploy-frontend-docker.yml
+++ b/.github/workflows/deploy-frontend-docker.yml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/metadata-action@v3.5.0
         with:
           images: ghcr.io/acm-mu/abacus-frontend
+          tags: latest ${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2.7.0


### PR DESCRIPTION
# Description

Add `latest` tag to docker deployments along with github sha to identify docker images.

Currently the remote package is labeled with the branch (`master`) so the command has to be
 `docker pull ghcr.io/acm-mu/abacus-frontend:master`

With this change, the tag will not be needed (because `latest` is inferred) and instead the command will be 
  `docker pull ghcr.io/acm-mu/abacus-frontend`

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Infrastructure
 

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
