### PR TITLE
🔧 MongoDB Update Item Patch

### DIFF
--- a/backend/src/api/submissions/putSubmissions.ts
+++ b/backend/src/api/submissions/putSubmissions.ts
@@ -104,7 +104,7 @@ export const putSubmissions = async (req: Request, res: Response) => {
   const item = matchedData(req)
 
   try {
-    const submission = await contest.get_submission(item.id)
+    const submission = await contest.get_submission(item.sid)
 
     if (item.claimed !== undefined && submission.claimed !== undefined) {
       // Trying to change a claimed submission

--- a/backend/src/services/db/mongo.ts
+++ b/backend/src/services/db/mongo.ts
@@ -65,7 +65,7 @@ export default class MongoDB extends Database {
       const unsetFields = Object.assign(
         {},
         ...Object.entries(Item)
-          .filter((obj) => obj[1] === undefined)
+          .filter((obj) => obj[1] === undefined || obj[1] === null)
           .map((obj) => ({ [`${obj[0]}`]: 1 }))
       )
 

--- a/backend/src/services/db/mongo.ts
+++ b/backend/src/services/db/mongo.ts
@@ -65,7 +65,7 @@ export default class MongoDB extends Database {
       const unsetFields = Object.assign(
         {},
         ...Object.entries(Item)
-          .filter((obj) => !obj[1])
+          .filter((obj) => obj[1] === undefined)
           .map((obj) => ({ [`${obj[0]}`]: 1 }))
       )
 


### PR DESCRIPTION
# Description

* Specifically check for `undefined` or `null` values when unsettling fields in mongo update operation.
* Update submission improperly retrieves submission using non-existent `id`.

Fixes #217 

## Type of change


- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

* Tested updating problem with `practice` field to boolean value that reproduces error described in #217  issue.

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->