### PR TITLE
Fix app styling being overridden by Semantic UI

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -37,7 +37,7 @@
     <title>Abacus</title>
 </head>
 
-<body>
+<body class="abacus">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -28,10 +28,10 @@ html {
   outline: none;
 }
 
-body {
-  background: var(--bg-color) !important;
-  color: #555 !important;
-  font-family: 'Open Sans', sans-serif !important;
+body:has(#root) {
+  background: var(--bg-color);
+  color: #555;
+  font-family: 'Open Sans', sans-serif;
   -moz-osx-font-smoothing: grayscale;
 }
 

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -29,9 +29,9 @@ html {
 }
 
 body {
-  background: var(--bg-color);
-  color: #555;
-  font-family: 'Open Sans', sans-serif;
+  background: var(--bg-color) !important;
+  color: #555 !important;
+  font-family: 'Open Sans', sans-serif !important;
   -moz-osx-font-smoothing: grayscale;
 }
 

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -28,7 +28,7 @@ html {
   outline: none;
 }
 
-body:has(#root) {
+body.abacus {
   background: var(--bg-color);
   color: #555;
   font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
# Description

The background color and some other CSS properties are being overridden by a newer version of Semantic UI.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->