### PR TITLE
🐞 Fix Problem Links in Gold Standings

### DIFF
--- a/frontend/src/pages/gold/Standings.tsx
+++ b/frontend/src/pages/gold/Standings.tsx
@@ -129,7 +129,7 @@ const Standings = (): React.JSX.Element => {
               {problems.map((problem) => (
                 <Table.HeaderCell key={problem.id} collapsing>
                   {user?.division === 'blue' || user?.role === 'admin' ? (
-                    <Link to={`/blue/problems/${problem.id}`}>{problem.id}</Link>
+                    <Link to={`/gold/problems/${problem.id}`}>{problem.id}</Link>
                   ) : (
                     problem.id
                   )}


### PR DESCRIPTION
# Description

The Problem Id links on the gold standings page link to blue problems. This is incorrect behavior and should link to gold problems instead.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->