### PR TITLE
Dn 323 + 303 + 325

### DIFF
--- a/backend/src/@types/abacus/index.d.ts
+++ b/backend/src/@types/abacus/index.d.ts
@@ -62,12 +62,14 @@ declare module 'abacus' {
     pid: string
     runtime: number
     released: boolean
+    released_date?: number
     score: number
     status: string
     sub_no: number
     tid: string
     tests: Test[]
     claimed?: string | User
+    claimed_date?: number
     viewed?: boolean
     flagged?: string | User
   }

--- a/backend/src/@types/abacus/index.d.ts
+++ b/backend/src/@types/abacus/index.d.ts
@@ -102,6 +102,8 @@ declare module 'abacus' {
    *           type: integer
    *         released:
    *           type: boolean
+   *         released_date:
+   *           type: integer
    *         score:
    *           type: integer
    *         status:
@@ -116,12 +118,15 @@ declare module 'abacus' {
    *             $ref: '#/components/schemas/Test'
    *         claimed:
    *           type: string
+   *         claimed_date:
+   *           type: integer
    *         viewed:
    *           type: boolean
    *         flagged:
    *           type: string
    *       required: [sid, date, filename, filesize, source, language, md5, pid, runtime, released, score, status, sub_no, tid, tests]
    */
+  
   export interface Submission extends RawSubmission {
     claimed?: string
     flagged?: string

--- a/backend/src/api/submissions/index.ts
+++ b/backend/src/api/submissions/index.ts
@@ -7,36 +7,47 @@ import { postSubmissions, schema as postSchema } from './postSubmissions'
 import { putSubmissions, schema as putSchema } from './putSubmissions'
 import { rerunSubmission, schema as rerunSchema } from './rerunSubmission'
 import { submissionsQueue } from './submissionsQueue'
-//import { doublyLinkedList } from './unranSubmissionsDoublyLinkedList'
+
 /**
  * @swagger
  * tags:
  *   name: Submissions
  */
 
+// Creating an Express Router to handle routes related to submissions
 const submissions = Router()
 
+// Route to get submissions
 submissions.get('/submissions', isAuthenticated, checkSchema(getSchema), getSubmissions)
+
+// Route to create a new submission
 submissions.post('/submissions', isAuthenticated, checkSchema(postSchema), postSubmissions)
+
+// Route to update an existing submission
 submissions.put('/submissions', hasRole('proctor'), checkSchema(putSchema), putSubmissions)
+
+// Route to delete a submission
 submissions.delete('/submissions', hasRole('admin'), checkSchema(deleteSchema), deleteSubmissions)
 
+// Route to rerun a submission
 submissions.post('/submissions/rerun', hasRole('judge'), checkSchema(rerunSchema), rerunSubmission)
 
+// Route to get the current state of the submissions queue
 submissions.get('/submissions/submissionsQueue', isAuthenticated, (_req: Request, res: Response) => {
     res.json(submissionsQueue.get())
 })
 
+// Route to dequeue a submission
 submissions.post('/submissions/submissionsDequeue', isAuthenticated, (req: Request, _res: Response) => {
     const { sid } = req.body
     submissionsQueue.dequeue(sid)
-    //console.log("backend/src/api/submissions/index.ts dequeue:", submissionsQueue);
-    //res.status(200).json({message: 'Submission with sid: ${sid dequeued'})
 })
 
+// Route to enqueue a submission
 submissions.post('/submissions/submissionsEnqueue', isAuthenticated, (req: Request, _res: Response) => {
     const { submission } = req.body
     submissionsQueue.enqueue(submission)
 })
 
+// Export the 'submissions' router to be used in the main app
 export default submissions

--- a/backend/src/api/submissions/index.ts
+++ b/backend/src/api/submissions/index.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express'
+import { Router, Request, Response } from 'express'
 import { checkSchema } from 'express-validator'
 import { hasRole, isAuthenticated } from '../../abacus/authlib'
 import { deleteSubmissions, schema as deleteSchema } from './deleteSubmissions'
@@ -6,6 +6,8 @@ import { getSubmissions, schema as getSchema } from './getSubmissions'
 import { postSubmissions, schema as postSchema } from './postSubmissions'
 import { putSubmissions, schema as putSchema } from './putSubmissions'
 import { rerunSubmission, schema as rerunSchema } from './rerunSubmission'
+import { submissionsQueue } from './submissionsQueue'
+//import { doublyLinkedList } from './unranSubmissionsDoublyLinkedList'
 /**
  * @swagger
  * tags:
@@ -20,5 +22,21 @@ submissions.put('/submissions', hasRole('proctor'), checkSchema(putSchema), putS
 submissions.delete('/submissions', hasRole('admin'), checkSchema(deleteSchema), deleteSubmissions)
 
 submissions.post('/submissions/rerun', hasRole('judge'), checkSchema(rerunSchema), rerunSubmission)
+
+submissions.get('/submissions/submissionsQueue', isAuthenticated, (_req: Request, res: Response) => {
+    res.json(submissionsQueue.get())
+})
+
+submissions.post('/submissions/submissionsDequeue', isAuthenticated, (req: Request, _res: Response) => {
+    const { sid } = req.body
+    submissionsQueue.dequeue(sid)
+    //console.log("backend/src/api/submissions/index.ts dequeue:", submissionsQueue);
+    //res.status(200).json({message: 'Submission with sid: ${sid dequeued'})
+})
+
+submissions.post('/submissions/submissionsEnqueue', isAuthenticated, (req: Request, _res: Response) => {
+    const { submission } = req.body
+    submissionsQueue.enqueue(submission)
+})
 
 export default submissions

--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -7,6 +7,7 @@ import { UploadedFile } from 'express-fileupload'
 import contest from '../../abacus/contest'
 import { Submission } from 'abacus'
 
+// Define the validation schema for the request body
 export const schema: Record<string, ParamSchema> = {
   pid: {
     in: 'body',
@@ -90,41 +91,52 @@ export const schema: Record<string, ParamSchema> = {
  *
  */
 
+// Function to handle the POST request for submissions
 export const postSubmissions = async (req: Request, res: Response): Promise<void> => {
+  // Check for validation errors in the request
   const errors = validationResult(req).array()
   if (errors.length > 0) {
+    // If validation fails, return an error response
     res.status(400).json({ message: errors[0].msg })
     return
   }
 
+  // Check to see if the user is authenticated
   if (!req.user) {
     res.status(401).send({ message: 'Your credentials could not be recognized!' })
     return
   }
   try {
+    // Get matched data from the request
     const item = matchedData(req)
 
+    // Get user data using the user's ID
     const user = await contest.get_user(req.user?.uid)
     if (!user) {
       res.status(401).send({ message: 'Your credentials could not be recognized!' })
       return
     }
 
+    // Check if the user account is disabled
     if (user.disabled) {
       res.status(403).send({ message: 'Your account is disabled!' })
       return
     }
 
+    // Get the problem data associated with the submission
     const problem = await contest.get_problem(item.pid)
     if (!problem) {
       res.status(400).send({ message: 'Problem does not exist!' })
       return
     }
+
+    // Checks if user is allowed to submit to the selected problem's division
     if (user?.division != problem.division) {
       res.status(403).send({ message: 'You can not submit to problems in this division!' })
       return
     }
 
+    // Get contest settings for the competition or practice period
     const {
       start_date,
       end_date,
@@ -132,6 +144,8 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
       practice_end_date
     } = await contest.get_settings()
     const now = Date.now()
+
+    // Check if the problem is in the practice period or competition period
     if (problem.practice) {
       if (now < practice_start_date * 1000) {
         res.status(403).send({ message: 'The practice period has not yet begun!' })
@@ -150,8 +164,10 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
       }
     }
 
+    // Get the user's previous submissions for the same problem
     const submissions = (await contest.get_submissions({ tid: req.user?.uid, pid: item.pid })) as Submission[]
 
+    // Check if the user has already solved the problem or if there are pending submissions
     if (submissions) {
       for (const submission of submissions) {
         if (submission.status === 'accepted' && problem.division != 'gold') {
@@ -170,6 +186,7 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
       }
     }
 
+    // Create a new submission object
     let submission: Record<string, unknown> = {
       sid: uuidv4().replace(/-/g, ''),
       pid: item.pid,
@@ -181,27 +198,30 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
       score: 0,
       date: Date.now() / 1000
     }
+
+    // Checks to see if the 'language' field is provided for blue submissions
     if (!item.language) {
       res.status(400).json({ message: 'language not provided' })
       return
     }
-    // Only run for new items
 
-    // Find submission from event metadata
-
-    // Get problem and competition details
+    // Handle blue division submissions
     if (item.division === 'blue') {
       if (req.files?.source == undefined) {
         res.status(400).json({ message: 'source not provided' })
         return
       }
+
+      // Get problem details
       const problem = await contest.get_problem(item.pid)
 
-      // Update status to 'pending'
-      // await updateItem('', { submission.sid }, { status: 'pending' });
+      // Create the submission
       await contest.create_submission({ sid: submission.sid, status: 'pending' })
+      
       // Extract details and set defaults
       const { name: filename, size: filesize, md5, data } = req.files.source as UploadedFile
+
+      // Update the submission with additional details
       submission = {
         ...submission,
         language: item.language,
@@ -211,68 +231,23 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
         tests: problem.tests,
         source: data.toString('utf-8')
       }
-      let status = 'pending'
-      /*for (let test of problem.tests) {
-        // Copy tests from problem
-        submission.tests = problem.tests
 
-        // Run tests
-        const file = { name: submission.filename as string, content: submission['source'] as string }
-        // Await response from piston execution
-        try {
-          const res = await axios.post(
-            'https://piston.tabot.sh/api/v2/execute',
-            {
-              language: item.language,
-              files: [file],
-              version: item.language === 'python' ? '3.9.4' : '15.0.2',
-              stdin: test.in
-            },
-            {
-              headers: {
-                'Content-Type': 'application/json'
-              }
-            }
-          )
-          test['stdout'] = res.data.run.code == 0 ? res.data.run.stdout : res.data.run.stderr
-          if ((res.data.run.output.trim() as string) == (test.out.trim() as string) && res.data.run.code === 0) {
-            console.log('Result: ACCEPTED')
-            test['result'] = 'accepted'
-          } else {
-            console.log('Result: REJECTED')
-            status = 'rejected'
-            test['result'] = 'rejected'
-          }
-        } catch (e) {
-          console.log(e)
-        }
-      }*/
-      submission.status = status
-      // Calculate Score
-      /*if (status == 'accepted') {
-        let minutes = 0
-        if (problem.practice) {
-          minutes = ((submission.date as any) - practice_start_date) / 60
-        } else {
-          minutes = ((submission.date as any) - start_date) / 60
-        }
-        submission.score = Math.floor(
-          minutes * points_per_minute + points_per_no * (submission.sub_no as any) + points_per_yes
-        )
-      } else {
-        submission.score = 0
-      }
-      */
+      // Set the submission status to 'pending'
+      submission.status = 'pending'
 
       // Save submission to database
       await contest.update_submission(submission.sid as string, { ...submission, sid: submission.sid })
-    } else if (req.user?.division == 'gold') {
+    }
+    // Handle gold division submissions (Scratch projects)
+    else if (req.user?.division == 'gold') {
+      // Fetch Scratch projects data using the project ID
       const scratchResponse = await axios.get(`https://api.scratch.mit.edu/projects/${item.project_id}`)
       if (scratchResponse.status !== 200) {
         res.status(400).send({ message: 'Server cannot access project with that id!' })
         return
       }
 
+      // Create a gold submission and mark it as accepted
       submission = {
         ...submission,
         status: 'accepted',
@@ -280,10 +255,12 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
         design_document: item.design_document,
         project_id: item.project_id
       }
+      // Save the gold submission
       await contest.create_submission(submission)
     }
     io.emit('new_submission', { sid: submission.sid })
 
+    // Send the submission details as the response
     res.send(submission)
   } catch (err) {
     console.error(err)

--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -129,10 +129,7 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
       start_date,
       end_date,
       practice_start_date,
-      practice_end_date,
-      points_per_yes,
-      points_per_minute,
-      points_per_no
+      practice_end_date
     } = await contest.get_settings()
     const now = Date.now()
     if (problem.practice) {
@@ -215,7 +212,7 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
         source: data.toString('utf-8')
       }
       let status = 'accepted'
-      for (let test of problem.tests) {
+      /*for (let test of problem.tests) {
         // Copy tests from problem
         submission.tests = problem.tests
 
@@ -249,10 +246,10 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
         } catch (e) {
           console.log(e)
         }
-      }
+      }*/
       submission.status = status
       // Calculate Score
-      if (status == 'accepted') {
+      /*if (status == 'accepted') {
         let minutes = 0
         if (problem.practice) {
           minutes = ((submission.date as any) - practice_start_date) / 60
@@ -265,6 +262,7 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
       } else {
         submission.score = 0
       }
+      */
 
       // Save submission to database
       await contest.update_submission(submission.sid as string, { ...submission, sid: submission.sid })

--- a/backend/src/api/submissions/postSubmissions.ts
+++ b/backend/src/api/submissions/postSubmissions.ts
@@ -211,7 +211,7 @@ export const postSubmissions = async (req: Request, res: Response): Promise<void
         tests: problem.tests,
         source: data.toString('utf-8')
       }
-      let status = 'accepted'
+      let status = 'pending'
       /*for (let test of problem.tests) {
         // Copy tests from problem
         submission.tests = problem.tests

--- a/backend/src/api/submissions/putSubmissions.ts
+++ b/backend/src/api/submissions/putSubmissions.ts
@@ -57,8 +57,18 @@ export const schema: Record<string, ParamSchema> = {
     isBoolean: true,
     optional: true
   },
+  released_date: {
+    in: 'body',
+    isNumeric: true,
+    optional: true
+  },
   claimed: {
     in: 'body',
+    optional: true
+  },
+  claimed_date: {
+    in: 'body',
+    isNumeric: true,
     optional: true
   },
   score: {
@@ -155,8 +165,13 @@ export const putSubmissions = async (req: Request, res: Response): Promise<void>
   }
   const item = matchedData(req)
 
+  //console.log("backend/src/api/submissions/putSubmission.ts:", req)
+  //console.log("backend/src/api/submissions/putSubmission.ts: item", item)
+
   try {
     const submission = await contest.get_submission(item.sid)
+
+    //console.log("backend/src/api/submissions/putSubmission.ts: here")
 
     if (item.claimed !== undefined && submission.claimed !== undefined) {
       // Trying to change a claimed submission
@@ -166,7 +181,14 @@ export const putSubmissions = async (req: Request, res: Response): Promise<void>
       }
     }
 
+    //console.log("backend/src/api/submissions/putSubmission.ts: before update submission")
+    //console.log("backend/src/api/submissions/putSubmission.ts: item.sid", item.sid)
+    //console.log("backend/src/api/submissions/putSubmission.ts: item", item)
+
     await contest.update_submission(item.sid, item)
+
+    
+    //console.log("backend/src/api/submissions/putSubmission.ts: after update submission")
 
     if (item.released == true) notifyTeam(item)
 

--- a/backend/src/api/submissions/putSubmissions.ts
+++ b/backend/src/api/submissions/putSubmissions.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { matchedData, ParamSchema, validationResult } from 'express-validator'
 import { io, sendNotification } from '../../server'
 import contest from '../../abacus/contest'
+//import { submissionsQueue } from './submissionsQueue'
 
 export const schema: Record<string, ParamSchema> = {
   sid: {
@@ -90,7 +91,7 @@ export const schema: Record<string, ParamSchema> = {
   }
 }
 
-const notifyTeam = async (item: Record<string, unknown>) => {
+export const notifyTeam = async (item: Record<string, unknown>) => {
   const res = await contest.get_submissions({ sid: item.sid })
   if (!res) return
 
@@ -104,6 +105,8 @@ const notifyTeam = async (item: Record<string, unknown>) => {
     }
   })
 }
+
+//const submissionsQueue = new SubmissionsQueue<Submission>()
 
 /**
  * @swagger
@@ -186,6 +189,10 @@ export const putSubmissions = async (req: Request, res: Response): Promise<void>
     //console.log("backend/src/api/submissions/putSubmission.ts: item", item)
 
     await contest.update_submission(item.sid, item)
+
+    //submissionsQueue.enqueue(submission)
+
+    //console.log("backend/src/spi/submissions/putSubmissions.ts submissionsQueue:", submissionsQueue)
 
     
     //console.log("backend/src/api/submissions/putSubmission.ts: after update submission")

--- a/backend/src/api/submissions/rerunSubmission.ts
+++ b/backend/src/api/submissions/rerunSubmission.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express'
 import { matchedData, ParamSchema, validationResult } from 'express-validator'
 import { contest } from '../../abacus'
 
+// Define the validation schema for the request body
 export const schema: Record<string, ParamSchema> = {
   sid: {
     in: 'body',
@@ -36,118 +37,83 @@ export const schema: Record<string, ParamSchema> = {
  *       500:
  *         description: A server error occurred while trying to complete request.
  */
+
+// Function to handle the POST request for rerunning a submission
 export const rerunSubmission = async (req: Request, res: Response): Promise<void> => {
+  // Check for validation errors in the request
   const errors = validationResult(req).array()
   if (errors.length > 0) {
+    // If validation fails, return a 400 Bad Request response
     res.status(400).json({ message: errors[0].msg })
     return
   }
+
+  // Get matched data from the request
   const item = matchedData(req)
+
   try {
+    // Get the submission data using the submission ID (sid)
     const submission = await contest.get_submission(item.sid)
+    // Get the problem associated with the submission
     const problem = await contest.get_problem(submission.pid)
 
+    // Get the contest settings such as start dates and points configuration
     const { start_date, practice_start_date, points_per_yes, points_per_minute, points_per_no } =
       await contest.get_settings()
+    
+    // Checks to see if submission exists
     if (submission) {
       submission.tests = problem.tests
       let num_testcases_wrong = 0
-      // Update status to 'pending'
-      // await updateItem('', { submission.sid }, { status: 'pending' });
-      // Extract details and set defaults
-      //let status = 'accepted'
+      
+      // Iterate through each test case to run and evaluate the submission
       for (let test of problem.tests) {
         // Copy tests from problem
         submission.tests = problem.tests
-        // Run tests
+        // Prepare the file and input for the test run
         const file = { name: submission.filename as string, content: submission['source'] as string }
-        // Await response from piston execution
-        /*try {
-          const res = await axios.post(
-            'https://piston.tabot.sh/api/v2/execute',
-            {
-              language: item.language as string,
-              files: [file],
-              version: '*',
-              stdin: test.in
-            },
-            {
-              headers: {
-                'Content-Type': 'application/json'
-              }
-            }
-          )
-          test['stdout'] = res.data.run.code == 0 ? res.data.run.stdout : res.data.run.stderr
-          if ((res.data.run.output.trim() as string) == (test.out.trim() as string) && res.data.run.code === 0) {
-            console.log('Result: ACCEPTED')
-            test['result'] = 'accepted'
-          } else {
-            console.log('Result: REJECTED')
-            status = 'rejected'
-            test['result'] = 'rejected'
-          }
-        } catch (e) {
-          console.log(e)
-        }
-      }
-
-      submission.status = status
-      // Calculate Score
-      if (status == 'accepted') {
-        let minutes = 0
-        if (problem.practice) {
-          minutes = ((submission.date as any) - practice_start_date) / 60
-        } else {
-          minutes = ((submission.date as any) - start_date) / 60
-        }
-        submission.score = Math.floor(
-          minutes * points_per_minute + points_per_no * (submission.sub_no as any) + points_per_yes
-        )
-      } else {
-        submission.score = 0
-      }
-      // update submission
-      await contest.update_submission(submission.sid as string, { ...submission, sid: submission.sid })
-      res.send(submission)*/
+      
       try {
+        // Send the submission source code to the piston runner API to execute
         const res = await axios.post(
-          'https://piston.tabot.sh/api/v2/execute',
+          'https://piston.tabot.sh/api/v2/execute', // API endpoint to execute the code
           {
-            language: submission.language as string,
-            version: '*',
-            files: [file],
-            stdin: test.in
+            language: submission.language as string, // Programming language of the submission
+            version: '*', // Use the latest version of the language
+            files: [file], // File containing the source code
+            stdin: test.in // Input data for the test case
           },
           {
             headers: {
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json' // Set the content type for the request
             }
           }
         )
+
+        // Capture the output from the piston runner response
         test['stdout'] = res.data.run.code == 0 ? res.data.run.stdout : res.data.run.stderr
 
-        //console.log("backend/src/api/submissions/rerunSubmission.ts res.data.run.stdout", res.data.run.stdout.trim())
-        //console.log("backend/src/api/submissions/rerunSubmission.ts test.out", test.out.trim())
-
+        // Compare the output with the expected output
         if(((res.data.run.stdout.trim() as string) == (test.out.trim() as string)))
         {
-          console.log('Result: ACCEPTED')
-          //submission.status = 'accepted'
+          // If the output is correct, mark as 'accepted'
           test['result'] = 'accepted'
         }
         else
         {
-          console.log('Result: REJECTED')
-         //submission.status = 'rejected'
+          // If output is incorrect, increment the counter for wrong test cases and mark as 'rejected'
           num_testcases_wrong += 1
           test['result'] = 'rejected'
         }
       }
       catch (e) {
+        // Handle any errors during the test run
         console.log(e)
       }
     }
-    //submission.status
+
+    /* If there are wrong test cases, the submission status is makred as 'rejected', 
+    otherwise the submission status is marked as 'accepted' */
     if(num_testcases_wrong > 0)
     {
       submission.status = "rejected"
@@ -156,11 +122,15 @@ export const rerunSubmission = async (req: Request, res: Response): Promise<void
     {
       submission.status = "accepted"
     }
-    //Calculate Score
+    
+    // Calculate the score for the submission
     if(submission.status == "accepted" || submission.status == "rejected")
     {
-      submission.sub_no = num_testcases_wrong
+      console.log("/backend/src/api/submissions/rerunSubmission.ts submission.sub_no", submission.sub_no)
+      
       let minutes = 0
+
+      // Calculate the time spent on the problem based on whether it's a practice or competition problem
       if(problem.practice)
       {
         minutes = ((submission.date as any) - practice_start_date) / 60
@@ -170,18 +140,23 @@ export const rerunSubmission = async (req: Request, res: Response): Promise<void
         minutes = ((submission.date as any) - start_date) / 60
       }
 
-      //console.log("backend/src/api/submissions/rerunSubmission.ts submission.sub_no", submission.sub_no)
-      submission.score = Math.floor(minutes * points_per_minute + points_per_no * (submission.sub_no as any) + points_per_yes)
+      // Calculate the final score based on time taken and the number of attempts
+      submission.score = Math.floor((minutes * points_per_minute) + (points_per_no * submission.sub_no) + points_per_yes)
     }
     else
     {
+      // If the submission is neither accepted or rejected, score is 0
       submission.score = 0
     }
-    //Save submission to database
+
+    // Save the updated submission to the database
     await contest.update_submission(submission.sid as string, {...submission, sid: submission.sid})
+
+    // Send the updated submission as a response
     res.send(submission)
   }
  } catch (err) {
+    // Handle any errors that occur during the process and send a 500 Internal Server Error response
     console.error(err)
     res.sendStatus(500)
   }

--- a/backend/src/api/submissions/submissionsDoublyLinkedList.ts
+++ b/backend/src/api/submissions/submissionsDoublyLinkedList.ts
@@ -1,0 +1,129 @@
+import { RawSubmission, Submission } from "abacus"
+
+class Node_<Submission extends RawSubmission>
+{
+    data: Submission;
+    next: Node_<Submission> | null = null
+    prev: Node_<Submission> | null = null
+
+    constructor(data: Submission)
+    {
+        this.data = data
+    }
+}
+
+class DoublyLinkedList<Submission extends RawSubmission>
+{
+    head: Node_<Submission> | null = null
+    tail: Node_<Submission> | null = null
+    size: number = 0
+
+    append(data: Submission): void
+    {
+        const newNode = new Node_(data)
+        if (this.tail)
+        {
+            this.tail.next = newNode
+            newNode.prev = this.tail
+            this.tail = newNode
+        }
+        else
+        {
+            this.head = this.tail = newNode
+        }
+        this.size++
+        console.log("backend/src/api/submissions/unranSubmissionsDoublyLL append:", this.print())
+    }
+
+    prepend(data: Submission): void
+    {
+        const newNode = new Node_(data)
+        if (this.head)
+        {
+            newNode.next = this.head
+            this.head.prev = newNode
+            this.head = newNode
+        }
+        else
+        {
+            this.head = this.tail = newNode
+        }
+        this.size++
+    }
+
+    remove(): void
+    {
+        if (this.tail)
+        {
+            if (this.tail.prev)
+            {
+                this.tail = this.tail.prev
+                this.tail.next = null
+            }
+            else
+            {
+                this.head = this.tail = null
+            }
+            this.size--
+        }
+    }
+
+    removeFirst(): void
+    {
+        if (this.head)
+        {
+            if (this.head.next)
+            {
+                this.head = this.head.next
+                this.head.prev = null
+            }
+            else
+            {
+                this.head = this.tail = null
+            }
+            this.size--
+            console.log("backend/src/api/submissions/unranSubmissionsDoublyLL removeFirst:", this.print())
+        }
+    }
+
+    getNodeAt(index: number): Node_<Submission> | null
+    {
+        //if(index < 0 || index >= this.size) return null;
+
+        let currentNode = this.head;
+        for (let i = 0; i < index; i++)
+        {
+            currentNode = currentNode?.next || null;
+        }
+
+        //this.removeFirst();
+
+        console.log("backend/src/api/submissions/unranSubmissionsDoublyLL getNodeAt:", currentNode)
+
+        return currentNode;
+    }
+
+    clear(): void
+    {
+        this.head = this.tail = null
+        this.size = 0
+    }
+
+    isEmpty(): boolean
+    {
+        return this.size === 0
+    }
+
+    print(): void {
+        let currentNode = this.head
+        let result = ""
+        while (currentNode) {
+            result += currentNode.data + "<->"
+            currentNode = currentNode.next
+        }
+        console.log(result.slice(0, -4))
+    }
+}
+
+export const doublyLinkedList = new DoublyLinkedList<Submission>()
+//doublyLinkedList.clear();

--- a/backend/src/api/submissions/submissionsDoublyLinkedList.ts
+++ b/backend/src/api/submissions/submissionsDoublyLinkedList.ts
@@ -1,8 +1,9 @@
 import { RawSubmission, Submission } from "abacus"
 
+// Define a Node clas to store a Submission and links to the next and previous nodes
 class Node_<Submission extends RawSubmission>
 {
-    data: Submission;
+    data: Submission
     next: Node_<Submission> | null = null
     prev: Node_<Submission> | null = null
 
@@ -12,12 +13,14 @@ class Node_<Submission extends RawSubmission>
     }
 }
 
+// Define a Doubly Linked List class to manage a list of submissions
 class DoublyLinkedList<Submission extends RawSubmission>
 {
     head: Node_<Submission> | null = null
     tail: Node_<Submission> | null = null
     size: number = 0
 
+    // Function to append a new node with submission data to the end of the list
     append(data: Submission): void
     {
         const newNode = new Node_(data)
@@ -32,9 +35,9 @@ class DoublyLinkedList<Submission extends RawSubmission>
             this.head = this.tail = newNode
         }
         this.size++
-        console.log("backend/src/api/submissions/unranSubmissionsDoublyLL append:", this.print())
     }
 
+    // Function to prepend a new node with submission data to the beginning of the list
     prepend(data: Submission): void
     {
         const newNode = new Node_(data)
@@ -51,6 +54,7 @@ class DoublyLinkedList<Submission extends RawSubmission>
         this.size++
     }
 
+    // Function to remove the last node in the list
     remove(): void
     {
         if (this.tail)
@@ -68,6 +72,7 @@ class DoublyLinkedList<Submission extends RawSubmission>
         }
     }
 
+    // Function to remove the first node in the list
     removeFirst(): void
     {
         if (this.head)
@@ -82,38 +87,35 @@ class DoublyLinkedList<Submission extends RawSubmission>
                 this.head = this.tail = null
             }
             this.size--
-            console.log("backend/src/api/submissions/unranSubmissionsDoublyLL removeFirst:", this.print())
         }
     }
 
+    // Function to get a node at a specific index in the list
     getNodeAt(index: number): Node_<Submission> | null
     {
-        //if(index < 0 || index >= this.size) return null;
-
-        let currentNode = this.head;
+        let currentNode = this.head
         for (let i = 0; i < index; i++)
         {
-            currentNode = currentNode?.next || null;
+            currentNode = currentNode?.next || null
         }
 
-        //this.removeFirst();
-
-        console.log("backend/src/api/submissions/unranSubmissionsDoublyLL getNodeAt:", currentNode)
-
-        return currentNode;
+        return currentNode
     }
 
+    // Function to clear the entire list
     clear(): void
     {
         this.head = this.tail = null
         this.size = 0
     }
 
+    // Function to check if the list is empty
     isEmpty(): boolean
     {
         return this.size === 0
     }
 
+    // Function to print the content of the list as a string
     print(): void {
         let currentNode = this.head
         let result = ""
@@ -125,5 +127,5 @@ class DoublyLinkedList<Submission extends RawSubmission>
     }
 }
 
+// Create an instance of DoublyLinkedList
 export const doublyLinkedList = new DoublyLinkedList<Submission>()
-//doublyLinkedList.clear();

--- a/backend/src/api/submissions/submissionsQueue.ts
+++ b/backend/src/api/submissions/submissionsQueue.ts
@@ -1,0 +1,83 @@
+import { RawSubmission, Submission, User } from "abacus"
+import { doublyLinkedList } from "./submissionsDoublyLinkedList"
+//import { notifyTeam } from "./putSubmissions"
+import { sendNotification } from '../../server'
+
+export class SubmissionsQueue<Submission extends RawSubmission>
+{
+    private submissions: Submission[] = []
+    private maxSize: number = 5
+
+    enqueue(item: Submission): void
+    {
+        if (this.submissions.length >= this.maxSize)
+        {
+            doublyLinkedList.append(item as import("abacus").Submission)
+            //console.log("backend/src/api/submissions/submissionsQueue LL append:", doublyLinkedList);
+            return
+        }
+        this.submissions.push(item)
+        console.log("backend/src/api/submissions/submissionsQueue enqueue:", this.submissions)
+    }
+
+    dequeue(sid: string): void
+    {
+        const index = this.submissions.findIndex(submission => submission.sid === sid)
+
+        if (index !== -1)
+        {
+            this.submissions.splice(index, 1)
+            console.log("backend/src/api/submissions/submissionsQueue dequeue:", this.submissions)
+        }
+
+        if (!doublyLinkedList.isEmpty())
+        {
+            const submission = doublyLinkedList.getNodeAt(0)?.data as Submission
+            this.submissions.push(submission)
+            doublyLinkedList.removeFirst()
+            console.log("backend/src/api/submissions/submissionsQueue submission.claimed:", submission.claimed)
+            const judgeInfo = submission.claimed as User
+            console.log("backend/src/api/submissions/submissionsQueue judgeInfo uid:", judgeInfo.uid)
+            sendNotification({
+                to: `uid:${judgeInfo.uid}`,
+                header: 'Rerun Now Available!',
+                content: `Submission ${submission.sid.substring(0, 8)} can now be ran`,
+                context: {
+                    type: 'sid',
+                    id: judgeInfo.uid as string
+                }
+            })
+            //io.emit('notification', { uid: judgeInfo.uid })
+
+            console.log("backend/src/api/submissions/submissionsQueue enqueue from LL:", this.submissions)
+        }
+    }
+
+    get(): Submission[]
+    {
+        return this.submissions
+    }
+
+    isEmpty(): boolean
+    {
+        return this.submissions.length == 0
+    }
+
+    size(): number
+    {
+        return this.submissions.length
+    }
+
+    clear(): void
+    {
+        this.submissions = []
+    }
+
+    contains(submission: Submission): boolean
+    {
+        return this.submissions.includes(submission)
+    }
+}
+
+export const submissionsQueue = new SubmissionsQueue<Submission>()
+//submissionsQueue.clear();

--- a/frontend/src/pages/admin/submissions/Submission.tsx
+++ b/frontend/src/pages/admin/submissions/Submission.tsx
@@ -8,65 +8,91 @@ import { AppContext } from 'context'
 import { saveAs } from 'file-saver'
 import { usePageTitle } from 'hooks'
 
+// unctional component for viewing and interacting with a specific submission
 const Submission = (): React.JSX.Element => {
+  // Set page title
   usePageTitle("Abacus | Admin Submission")
 
+  // Get the submission ID from URL params
   const { sid } = useParams<{ sid: string }>()
+  // State to hold submission details
   const [submission, setSubmission] = useState<SubmissionType>()
+  // State for loading status
   const [isLoading, setLoading] = useState(true)
+  // State to track mounted status
   const [isMounted, setMounted] = useState(true)
+  // State to track rerun status
   const [isRerunning, setRerunning] = useState(false)
+  // State to track release status
   const [isReleasing, setReleasing] = useState(false)
+  // State to track delete status
   const [isDeleting, setDeleting] = useState(false)
+  // State to track flag status
   const [isFlagging, setFlagging] = useState<{ [key: string]: boolean }>({})
+  // State to track unflag status
   const [isUnFlagging, setUnFlagging] = useState<{ [key: string]: boolean }>({})
+  // State to track save status
   const [isSaving, setSaving] = useState(false)
+  // State to store submission queue
   const [queue, setQueue] = useState<SubmissionType[]>([])
 
+  // Get user details from context
   const { user } = useContext(AppContext)
 
+  // Hook to navigate between routes
   const navigate = useNavigate()
 
+  // Function to load submission details by its ID
   const loadSubmission = async () => {
     const response = await fetch(`${config.API_URL}/submissions?sid=${sid}`, {
+      // Authorization using stored token
       headers: { Authorization: `Bearer ${localStorage.accessToken}` }
     })
 
     if (!isMounted) return
 
     if (response.ok) {
+      // Update the submission state with data from the response
       setSubmission(Object.values(await response.json())[0] as SubmissionType)
     }
+    // Stop loading after fetching data
     setLoading(false)
   }
 
+  // Function to load submissions queue
   const loadQueue = async () => {
       const response = await fetch(`${config.API_URL}/submissions/submissionsQueue`,{
         headers: { Authorization: `Bearer ${localStorage.accessToken}` }
       })
   
-      console.log("/frontend/src/pages/judge/Submission.tsx loadQueue response:", response)
-  
       if (response.ok) {
+        // Get the submission queue data
         const queueData = await response.json()
+        // Set the queue data to state
         setQueue(queueData)
-        console.log("frontend/src/pages/judge/Submission.tsx loadQueue here")
       }
     }
 
+  // Hook to get submission data and queue when component is mounted or 'sid' changes
   useEffect(() => {
+    // Load the submission details
     loadSubmission()
+    // Load the queue data
     loadQueue()
     return () => {
       setMounted(false)
     }
   }, [])
 
+  // Show loading screen while fetching data
   if (isLoading) return <PageLoading />
+  // Show not found page if submission doesn't exist
   if (!submission) return <NotFound />
 
+  // Function to handle submission deletion
   const deleteSubmission = async () => {
     if (!sid) return
+    // Confirmation dialog before deletion
     if (window.confirm('Are you sure you want to delete this submission?')) {
       //if the user selects ok, then the code below runs, otherwise nothing occurs
       setDeleting(true)
@@ -85,12 +111,14 @@ const Submission = (): React.JSX.Element => {
           header: 'Success!',
           content: 'We deleted the submission you selected!'
         })
+        // Redirect to the submissions page after deletion
         navigate('/admin/submissions')
       }
       setDeleting(false)
     }
   }
 
+  // Function to rerun a submission
   const rerun = async () => {
     if (!setSubmission) return
     setRerunning(true)
@@ -110,6 +138,8 @@ const Submission = (): React.JSX.Element => {
     }
     setRerunning(false)
   }
+
+  // Function to release the submission
   const release = async () => {
     if (!setSubmission) return
     if (!submission) return
@@ -135,6 +165,7 @@ const Submission = (): React.JSX.Element => {
     setReleasing(false)
   }
 
+  // Function to save submission changes
   const save = async () => {
     setSaving(true)
 
@@ -149,6 +180,7 @@ const Submission = (): React.JSX.Element => {
     setSaving(false)
   }
 
+  // Function to flag the submission
   const flag = async () => {
     if (!sid) return
     setFlagging({ ...isFlagging, [sid]: true })
@@ -168,6 +200,7 @@ const Submission = (): React.JSX.Element => {
     setFlagging({ ...isFlagging, [sid]: false })
   }
 
+  // Function to unflag the submission
   const unflag = async () => {
     if (!sid) return
     setUnFlagging({ ...isUnFlagging, [sid]: true })
@@ -187,11 +220,13 @@ const Submission = (): React.JSX.Element => {
     setUnFlagging({ ...isUnFlagging, [sid]: false })
   }
 
+  // Function to download the submission source code file
   const download = () =>
     submission?.source &&
     submission.filename &&
     saveAs(new File([submission?.source], submission.filename, { type: 'text/plain;charset=utf-8' }))
   
+  // Function to dequeue submission
   const dequeue = async () => {
     const response = await fetch(`${config.API_URL}/submissions/submissionsDequeue`, {
       method: 'POST',
@@ -201,21 +236,20 @@ const Submission = (): React.JSX.Element => {
       },
       body: JSON.stringify({sid: submission.sid})
     })
-  
-    console.log("/frontend/src/pages/judge/Submission.tsx dequeue response:", response)
-  
-    if (response.ok) {
-      console.log("frontend/src/pages/judge/Submission.tsx dequeue here")
-    }
   }
   
+  // Function to dequeue and release submission
   const dequeue_release = () => {
     release()
     dequeue()
   }
 
+  /* This displays the queue in the console tab when inspecting the web site (right click on website and select inspect). 
+     The queue will show everytime a submission page is loaded (when clicking on a submission ID of a submission). 
+     This log will be useful as currently there is no other way to view the queue. */
   console.log("frontend/src/pages/judge/submission.tsx queue:", queue)
 
+  // Render submission page with buttons for various actions
   return (
     <Grid>
       <Button content="Back" icon="arrow left" labelPosition="left" onClick={() => navigate(-1)} />

--- a/frontend/src/pages/admin/submissions/Submission.tsx
+++ b/frontend/src/pages/admin/submissions/Submission.tsx
@@ -236,6 +236,11 @@ const Submission = (): React.JSX.Element => {
       },
       body: JSON.stringify({sid: submission.sid})
     })
+
+    if (response.ok)
+    {
+      console.log("frontend/src/pages/admin/submissions/Submission.tsx dequeue here")
+    }
   }
   
   // Function to dequeue and release submission

--- a/frontend/src/pages/judge/Submission.tsx
+++ b/frontend/src/pages/judge/Submission.tsx
@@ -247,10 +247,14 @@ const Submission = (): React.JSX.Element => {
   const refresh = () =>
     window.location.reload()
 
-  const rerun_dequeue_refresh = () => {
+  const rerun_refresh = () => {
     rerun()
-    dequeue()
     refresh()
+  }
+
+  const dequeue_release = () => {
+    release()
+    dequeue()
   }
 
   // const claim_refresh = (sid: string) => {
@@ -301,7 +305,7 @@ const Submission = (): React.JSX.Element => {
                     content="Rerun"
                     icon="redo"
                     labelPosition="left"
-                    onClick={rerun_dequeue_refresh}
+                    onClick={rerun_refresh}
                   />
                 )}
                 <Button
@@ -310,7 +314,7 @@ const Submission = (): React.JSX.Element => {
                   icon="right arrow"
                   content="Release"
                   labelPosition="left"
-                  onClick={release}
+                  onClick={dequeue_release}
                 />
               </>
             ) : (

--- a/frontend/src/pages/judge/Submission.tsx
+++ b/frontend/src/pages/judge/Submission.tsx
@@ -8,85 +8,85 @@ import { AppContext, SocketContext } from 'context'
 import { saveAs } from 'file-saver'
 import { usePageTitle } from 'hooks'
 
+// Functional component for viewing and interacting with a specific submission
 const Submission = (): React.JSX.Element => {
+  // Set the page title for the current view
   usePageTitle("Abacus | Judge Submission")
 
+  // Contexts to get socket connection and app-wide state
   const socket = useContext(SocketContext)
+  // Get submission ID from route paramters
   const { sid } = useParams<{ sid: string }>()
+  // State to hold submission details
   const [submission, setSubmission] = useState<SubmissionType>()
+  // State for loading status
   const [isLoading, setLoading] = useState(true)
+  // State to track rerun status
   const [isRerunning, setRerunning] = useState(false)
+  // State to track release status
   const [isReleasing, setReleasing] = useState(false)
+  // State to track claiming status
   const [isClaiming, setClaiming] = useState<{ [key: string]: boolean }>({})
+  // State for error messages
   const [error, setError] = useState<string>()
+  // State to store submission queue
   const [queue, setQueue] = useState<SubmissionType[]>([])
 
+  // Get user details from context
   const { user } = useContext(AppContext)
 
+  // Hook to navigate between routes
   const navigate = useNavigate()
 
+  // Function to load submission details by its ID
   const loadSubmission = async () => {
     const response = await fetch(`${config.API_URL}/submissions?sid=${sid}`, {
+      // Authorization using stored token
       headers: { Authorization: `Bearer ${localStorage.accessToken}` }
     })
 
 
     if (response.ok) {
+      // Update the submission state with data from the response
       setSubmission(Object.values(await response.json())[0] as SubmissionType)
     }
+    // Stop loading after fetching data
     setLoading(false)
   }
 
+  // Function to load submissions queue
   const loadQueue = async () => {
     const response = await fetch(`${config.API_URL}/submissions/submissionsQueue`,{
       headers: { Authorization: `Bearer ${localStorage.accessToken}` }
     })
 
-    console.log("/frontend/src/pages/judge/Submission.tsx loadQueue response:", response)
-
     if (response.ok) {
+      // Get the submission queue data
       const queueData = await response.json()
+      // Set the queue data to state
       setQueue(queueData)
-      console.log("frontend/src/pages/judge/Submission.tsx loadQueue here")
     }
   }
 
-  /*
-  const addToQueue = async () => {
-    const response = await fetch(`${config.API_URL}/submissions/submissionsQueue`,{
-      headers: { Authorization: `Bearer ${localStorage.accessToken}` }
-    })
-
-    console.log("/frontend/src/pages/judge/Submission.tsx addToQueue response:", response)
-
-    if (response.ok) {
-      const queueData = await response.json()
-      setQueue(queueData);
-      console.log("frontend/src/pages/judge/Submission.tsx addToQueue here")
-    }
-  }
-    */
-
+  // Hook to get submission data and queue when component is mounted or 'sid' changes
   useEffect(() => {
+    // Load the submission details
     loadSubmission().then(() => setLoading(false))
+    // Load the queue data
     loadQueue()
+    // Listen for 'update_submission' events from socket
     socket?.on('update_submission', loadSubmission)
-  }, [sid])
+  }, [sid]) // Dependency on 'sid' to refetch data when it changes
 
+  // Show loading screen while fetching data
   if (isLoading) return <PageLoading />
+  // Show not found page if submission doesn't exist
   if (!submission) return <NotFound />
 
-  // const loadSubmissionsQueue = async () => {
-  //   const response = await fetch(`${config.API_URL}/submissions/submissionsQueue`, {
-  //     headers: { Authorization: `Bearer ${localStorage.accessToken}`}
-  //   })
-
-  //   //if(response.ok)
-  // }
-
-
+  // Function to rerun a submission
   const rerun = async () => {
     if (!setSubmission) return
+    // Start rerun process
     setRerunning(true)
     const response = await fetch(`${config.API_URL}/submissions/rerun`, {
       method: 'POST',
@@ -94,7 +94,7 @@ const Submission = (): React.JSX.Element => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${localStorage.accessToken}`
       },
-      body: JSON.stringify({ sid: submission.sid })
+      body: JSON.stringify({ sid: submission.sid }) // Send submission ID to rerun it
     })
     if (response.ok) {
       const result = await response.json()
@@ -104,17 +104,21 @@ const Submission = (): React.JSX.Element => {
     } else {
       try {
         const { message } = await response.json()
+        // Show error if rerun fails
         setError(message)
       } catch (_err) {
         return
       }
     }
+    // Stop rerun process
     setRerunning(false)
   }
 
+  // Function to release a submission after scoring
   const release = async () => {
     if (!setSubmission) return
     if (!submission) return
+    // Start releasing process
     setReleasing(true)
     const response = await fetch(`${config.API_URL}/submissions`, {
       method: 'PUT',
@@ -143,10 +147,13 @@ const Submission = (): React.JSX.Element => {
         return
       }
     }
+    // Stop releasing process
     setReleasing(false)
   }
 
+  // Function to claim a submission
   const claim = async (sid: string) => {
+    // Set claiming status for the submission
     setClaiming({ ...isClaiming, [sid]: true })
     const response = await fetch(`${config.API_URL}/submissions`, {
       method: 'PUT',
@@ -158,25 +165,30 @@ const Submission = (): React.JSX.Element => {
     })
 
     if (response.ok) {
+      // Update submission state with the claiming info
       setSubmission({...submission, claimed: user, claimed_date: Date.now() / 1000})
       const updatedSubmission = { ...submission, claimed: user, claimed_date: Date.now() / 1000}
-      //setSubmission(updatedSubmission)
+      // Enqueue the claimed submission
       enqueue(updatedSubmission)
+      // Reload queue after claiming
       loadQueue()
-      //addToQueue()
     } else {
       try {
         const { message } = await response.json()
+        // Show error if claiming fails
         setError(message)
       } catch (_err) {
         return
       }
     }
 
+    // Stop claiming process
     setClaiming({ ...isClaiming, [sid]: false })
   }
 
+  // Function to unclaim a submission
   const unclaim = async (sid: string) => {
+    // Set unclaiming status
     setClaiming({ ...isClaiming, [sid]: true })
     const response = await fetch(`${config.API_URL}/submissions`, {
       method: 'PUT',
@@ -188,24 +200,29 @@ const Submission = (): React.JSX.Element => {
     })
 
     if (response.ok) {
+      // Clear claimed status
       setSubmission({ ...submission, claimed: undefined })
     } else {
       try {
         const { message } = await response.json()
+        // Show error if unclaiming fails
         setError(message)
       } catch (_err) {
         return
       }
     }
 
+    // Stop unclaiming process
     setClaiming({ ...isClaiming, [sid]: false })
   }
 
+  // Function to download the source code of the submission
   const download = () =>
     submission?.source &&
     submission.filename &&
     saveAs(new File([submission?.source], submission.filename, { type: 'text/plain;charset=utf-8' }))
   
+  // Function to enqueue a submission into the submission queue
   const enqueue = async (submission: SubmissionType) => {
     const response = await fetch(`${config.API_URL}/submissions/submissionsEnqueue`, {
       method: 'POST',
@@ -213,20 +230,19 @@ const Submission = (): React.JSX.Element => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${localStorage.accessToken}`
       },
-      body: JSON.stringify({submission})
+      body: JSON.stringify({submission}) // Send submission to enqueue
     })
 
-    console.log("/frontend/src/pages/judge/Submission.tsx enqueue response:", response)
-
     if (response.ok) {
-      //loadQueue()
       const queueData = await response.json()
+      // Update the queue state
       setQueue(queueData)
+      // Reload the queue after enqueuing
       loadQueue()
-      console.log("frontend/src/pages/judge/Submission.tsx enqueue here")
     }
   }
 
+  // Function to dequeue a submission from the submission queue
   const dequeue = async () => {
     const response = await fetch(`${config.API_URL}/submissions/submissionsDequeue`, {
       method: 'POST',
@@ -234,50 +250,41 @@ const Submission = (): React.JSX.Element => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${localStorage.accessToken}`
       },
-      body: JSON.stringify({sid: submission.sid})
+      body: JSON.stringify({sid: submission.sid}) // Send submission to dequeue
     })
-
-    console.log("/frontend/src/pages/judge/Submission.tsx dequeue response:", response)
-
-    if (response.ok) {
-      console.log("frontend/src/pages/judge/Submission.tsx dequeue here")
-    }
   }
 
+  // Function to refresh the page
   const refresh = () =>
     window.location.reload()
 
+  // Function to rerun the submission and refresh the page after
   const rerun_refresh = () => {
     rerun()
     refresh()
   }
 
-  const dequeue_release = () => {
+  // Function to release and dequeue the submission
+  const release_dequeue = () => {
     release()
     dequeue()
   }
 
-  // const claim_refresh = (sid: string) => {
-  //   claim(sid)
-  //   refresh()
-  // }
-
-  // function rerun_dequeue_refresh()
-  // {
-  //   rerun()
-  //   dequeue()
-  //   refresh()
-  // }
-
+  // Function to claim a submission and reload the queue
   const claim_loadQueue = (sid: string) => {
     claim(sid)
     loadQueue()
   }
 
+  /* This displays the queue in the console tab when inspecting the web site (right click on website and select inspect). 
+     The queue will show everytime a submission page is loaded (when clicking on a submission ID of a submission). 
+     This log will be useful as currently there is no other way to view the queue. */
   console.log("frontend/src/pages/judge/submission.tsx queue:", queue)
 
+  // Disable rerun button if submission is not in the queue
   const isRerunDisabled = !queue.some((item) => item.sid === submission?.sid)
 
+  // Render submission page with buttons for various actions
   return (
     <>
 
@@ -314,7 +321,7 @@ const Submission = (): React.JSX.Element => {
                   icon="right arrow"
                   content="Release"
                   labelPosition="left"
-                  onClick={dequeue_release}
+                  onClick={release_dequeue}
                 />
               </>
             ) : (

--- a/frontend/src/pages/judge/Submission.tsx
+++ b/frontend/src/pages/judge/Submission.tsx
@@ -252,6 +252,11 @@ const Submission = (): React.JSX.Element => {
       },
       body: JSON.stringify({sid: submission.sid}) // Send submission to dequeue
     })
+    
+    if(response.ok)
+    {
+      console.log("frontend/src/pages/judge/Submission.tsx dequeue here")
+    }
   }
 
   // Function to refresh the page

--- a/frontend/src/pages/judge/Submission.tsx
+++ b/frontend/src/pages/judge/Submission.tsx
@@ -85,13 +85,14 @@ const Submission = (): React.JSX.Element => {
         feedback: submission.feedback,
         score: submission.score,
         released: true,
+        released_date: Date.now() / 1000,
         claimed: undefined,
         status: submission.status
       })
     })
     if (response.ok) {
       const result = await response.json()
-      setSubmission({ ...submission, released: result.released, claimed: undefined })
+      setSubmission({ ...submission, released: result.released, released_date: Date.now() / 1000, claimed: undefined })
     } else {
       try {
         const { message } = await response.json()
@@ -111,11 +112,11 @@ const Submission = (): React.JSX.Element => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${localStorage.accessToken}`
       },
-      body: JSON.stringify({ sid, claimed: user?.uid })
+      body: JSON.stringify({ sid, claimed: user?.uid, claimed_date: Date.now() / 1000 })
     })
 
     if (response.ok) {
-      setSubmission({ ...submission, claimed: user })
+      setSubmission({ ...submission, claimed: user, claimed_date: Date.now() / 1000})
     } else {
       try {
         const { message } = await response.json()

--- a/frontend/src/pages/judge/Submissions.tsx
+++ b/frontend/src/pages/judge/Submissions.tsx
@@ -100,6 +100,11 @@ const Submissions = (): React.JSX.Element => {
         },
         body: JSON.stringify({submission})
       })
+
+      if (response.ok)
+      {
+        console.log("frontend/src/pages/judge/Submissions.tsx enqueue here")
+      }
     }
 
     // Toggle filter for showing released submissions

--- a/frontend/src/pages/judge/Submissions.tsx
+++ b/frontend/src/pages/judge/Submissions.tsx
@@ -19,29 +19,43 @@ type SortConfig = {
   direction: 'ascending' | 'descending'
 }
 
+// Functional component for viewing and interacting with multiple submissions
 const Submissions = (): React.JSX.Element => {
+  // Set the page title for the submissions page
   usePageTitle("Abacus | Judge Submissions")
 
+  // Using socket context for real-time updates
   const socket = useContext(SocketContext)
+  // Track loading state
   const [isLoading, setLoading] = useState(true)
+  // Store the submissions list
   const [submissions, setSubmissions] = useState<SubmissionItem[]>([])
+  // Track component mounted status
   const [isMounted, setMounted] = useState(true)
+  // Track the deleting state
   const [isDeleting, setDeleting] = useState(false)
+  // Track claiming state for each submission
   const [isClaiming, setClaiming] = useState<{ [key: string]: boolean }>({})
+  // Flag to toggle visibility of released submissions
   const [showReleased, setShowReleased] = useState(false)
+  // Get filter query parameter from URL
   const filter = new URLSearchParams(window.location.search).get('filter')
 
+  // Access the user context to retrieve current user data
   const { user } = useContext(AppContext)
 
+  // Sort configuration state management
   const [{ column, direction }, setSortConfig] = useState<SortConfig>({
     column: 'date',
     direction: 'ascending'
   })
 
+  // Function to handle sorting of submissions based on column selection
   const sort = (newColumn: SortKey, submission_list: SubmissionItem[] = submissions) => {
     const newDirection = column === newColumn && direction == 'ascending' ? 'descending' : 'ascending'
     setSortConfig({ column: newColumn, direction: newDirection })
 
+    // Sorting the list of submissions based on the column and direction
     setSubmissions(
       submission_list.sort(
         (s1: Submission, s2: Submission) =>
@@ -50,6 +64,7 @@ const Submissions = (): React.JSX.Element => {
     )
   }
 
+  // Effect hook to load submissions on component mount and set up socket listeners for real-time updates
   useEffect(() => {
     loadSubmissions().then(() => setLoading(false))
     socket?.on('new_submission', loadSubmissions)
@@ -57,6 +72,7 @@ const Submissions = (): React.JSX.Element => {
     return () => setMounted(false)
   }, [])
 
+  // Function to load submissions from API and filter out disabled teams
   const loadSubmissions = async () => {
     const response = await fetch(`${config.API_URL}/submissions?division=${user?.division}`, {
       headers: {
@@ -74,8 +90,8 @@ const Submissions = (): React.JSX.Element => {
     )
   }
 
+  // Function to enqueue a submission to the queue
   const enqueue = async (submission: Submission) => {
-      //const submission = submissions.find((submission) => submission.sid === sid)
       const response = await fetch(`${config.API_URL}/submissions/submissionsEnqueue`, {
         method: 'POST',
         headers: {
@@ -84,28 +100,30 @@ const Submissions = (): React.JSX.Element => {
         },
         body: JSON.stringify({submission})
       })
-  
-      console.log("/frontend/src/pages/judge/Submission.tsx enqueue response:", response)
-  
-      if (response.ok) {
-        console.log("frontend/src/pages/judge/Submission.tsx enqueue here")
-      }
     }
 
+    // Toggle filter for showing released submissions
   const onFilterChange = () => setShowReleased(!showReleased)
 
+  // Function to download submissions as a JSON file
   const downloadSubmissions = () =>
     saveAs(new File([JSON.stringify(submissions, null, '\t')], 'submissions.json', { type: 'text/json;charset=utf-8' }))
+
+  // Handle individual checkbox state change
   const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) =>
     setSubmissions(submissions.map((submission) => (submission.sid == id ? { ...submission, checked } : submission)))
+
+  // Handle "check all" checkbox state change
   const checkAll = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) =>
     setSubmissions(submissions.map((submission) => ({ ...submission, checked })))
 
+  // Delete selected submissions
   const deleteSelected = async () => {
     setDeleting(true)
     const submissionsToDelete = submissions
       .filter((submission) => submission.checked)
       .map((submission) => submission.sid)
+    // Send request to delete selected submissions
     const response = await fetch(`${config.API_URL}/submissions`, {
       method: 'DELETE',
       headers: {
@@ -115,11 +133,13 @@ const Submissions = (): React.JSX.Element => {
       body: JSON.stringify({ sid: submissionsToDelete })
     })
     if (response.ok) {
+      // Reload submissions after successful deletion
       loadSubmissions()
     }
     setDeleting(false)
   }
 
+  // Function to claim a submission (assign it to the current user)
   const claim = async (sid: string) => {
     setClaiming({ ...isClaiming, [sid]: true })
     const response = await fetch(`${config.API_URL}/submissions`, {
@@ -135,12 +155,14 @@ const Submissions = (): React.JSX.Element => {
       setSubmissions(submissions.map((sub) => (sub.sid == sid ? { ...sub, claimed: user } : sub)))
       const oldSubmission = submissions.filter((sub) => sub.sid === sid)[0]
       const updatedSubmission = { ...oldSubmission, claimed: user, claimed_date: Date.now() / 1000 } as Submission
+      // Enqueue the updated submission
       enqueue(updatedSubmission)
     }
 
     setClaiming({ ...isClaiming, [sid]: false })
   }
 
+  // Function to unclaim a submission (release it from the current user)
   const unclaim = async (sid: string) => {
     setClaiming({ ...isClaiming, [sid]: true })
     const response = await fetch(`${config.API_URL}/submissions`, {
@@ -159,6 +181,7 @@ const Submissions = (): React.JSX.Element => {
     setClaiming({ ...isClaiming, [sid]: false })
   }
 
+  // URL filter function for filtering based on submission status
   const urlFilter = ({ claimed }: Submission) => {
     switch (filter) {
       case 'my_claimed':
@@ -174,23 +197,13 @@ const Submissions = (): React.JSX.Element => {
     }
   }
 
-  const claim_enqueue = (sid: string) => {
-    claim(sid)
-    //enqueue()
-  }
-
-  // function claim_enqueue(sid: string)
-  // {
-  //   claim(sid)
-  //   enqueue()
-
-  // }
-
+  // Filter list of submissions based on the selected filter and showReleased flag
   const filteredSubmissions = useMemo(
     () => submissions.filter((submission) => showReleased || (!submission.released && urlFilter(submission))),
     [submissions, showReleased, filter]
   )
 
+  // Show loading spinner if data is still being fetched
   if (isLoading) return <PageLoading />
 
   return (
@@ -299,7 +312,7 @@ const Submissions = (): React.JSX.Element => {
                       <Button
                         content="Claim"
                         icon={'hand rock'}
-                        onClick={() => claim_enqueue(submission.sid)}
+                        onClick={() => claim(submission.sid)}
                         loading={isClaiming[submission.sid]}
                         disabled={isClaiming[submission.sid]}
                         labelPosition={'left'}

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -18,6 +18,7 @@ declare module 'abacus' {
     division: string
     language: string
     released: boolean
+    released_date?: number
     claimed?: User
     tid: string
     team?: Team
@@ -27,6 +28,7 @@ declare module 'abacus' {
     score: number
     feedback?: string
     claimed?: User
+    claimed_date?: number
     flagged?: User
     viewed?: boolean
     //Blue


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed or feature request is implemented. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #323
- Integrate piston runner changes from branch 2024-changes
- Submissions get sent to the database instead of being sent to Piston when a team submits their submission
- This will help with the load for Piston

Fixes #303
- Grading algorithm now takes into account the number of attempts a team takes to solve a problem

Fixes #325
- A queue and doubly linked list were implemented to help with Piston load
- Up to five submissions can be in the queue, after that the other submissions get sent to the doubly linked list. A submission can only be sent to piston if it is in the queue. A submission from the doubly linked list gets sent to the queue when a submission in the queue gets dequeued, which is when a judge releases the submission to the team


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->

- [X] 💡 New feature
<!-- Non-breaking change which adds functionality -->

- [ ] ⚠️ Breaking change
<!-- 
  - Changes a method signature.
  - Changes the behavior of a method.
  - Changes settings, configuration. -->

- [X] 🧹 Code Cleanup
<!-- General Code Cleanup like removing stale files, comments, etc. -->

- [ ] 📚 Documentation Change
<!-- Changes to documentation only -->
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested individually.
<!-- Performed tests individually on a development deployment. -->
Issue #323
- When submitting a submission as a team, the submission is not automatically sent to Piston and scored. When looking at the database, the submission is not scored
- When logged in as a judge, claim the submission and click on rerun. The submission will be sent to Piston and be scored

Issue #303
- When submitting multiple incorrect submissions, there will be a penalty added to the score
- The penalty value can be changed in the settings tab when logged in as admin. Under the Scoring System section, change the value for "Points per No"
- When a team submits their submission, there is no penalty. For every subsequent submission, the value for "Points per No" gets added to the score (Ex. If "Points per No" = 20, 1st attempt - No penalty, 2nd attempt - 20 points added to score, 3rd attempt - 40 points added to score)
- Submit an incorrect submission as a team. Claim, rerun, and release the submission as a judge. Repeat this and the score will be calculated as (time it took to submit + (20 * attempts) (not counting the first attempt)) (Ex. If the submission was submitted when the competition has been going on for 15 minutes and it was the third attempt, then the score will be 55)

Issue #325
- Send at least 6 submissions to Abacus. 
- Log in as a judge and claim at least 6 submissions. A notification will appear when the 6th and subsequent submissions are claimed saying that rerun is unavailable since the submission is not in the queue
- For the first 5 submissions that were claimed, the rerun button is clickable, but for the rest of the claimed submissions, the button is grey out and not clickable
- As a judge, run and release a submission. After releasing a submission, a notification will appear saying that a submission that was previously not in the queue is now in the queue and rerun is available for that submission

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->