### PR TITLE
2025 pagination

### DIFF
--- a/frontend/src/components/ClarificationModal.tsx
+++ b/frontend/src/components/ClarificationModal.tsx
@@ -12,6 +12,7 @@ interface ClarificationModalProps {
   title?: string
   context?: Context
   callback?: (clarification: Clarification) => void
+  onCreate?: () => void;
 }
 
 const ClarificationModal = ({ trigger, title = '', context }: ClarificationModalProps): React.JSX.Element => {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Table, Loader, Message, Icon } from 'semantic-ui-react'
 import { Countdown, Block, DivisionLabel } from 'components'
 import { Link } from 'react-router-dom'
+import {Button} from 'semantic-ui-react'
 
 type TeamType = {
   division: string
@@ -15,7 +16,10 @@ const Home = (): React.JSX.Element => {
   const [isLoading, setLoading] = useState(true)
   const [teams, setTeams] = useState<TeamType[]>([])
   const [isMounted, setMounted] = useState(true)
-
+ 
+  const [currentPage, setCurrentPage] = useState<number>(1)
+  const ITEMS_PER_PAGE = 25 
+  
   const loadTeams = () => {
     fetch('https://mu.acm.org/api/registered_teams')
       .then((res) => res.json())
@@ -34,16 +38,20 @@ const Home = (): React.JSX.Element => {
       clearInterval(teamFetchInterval)
       setMounted(false)
     }
-  })
+  }, [] )
+
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const paginatedTeams = teams.slice(startIndex, endIndex); 
 
   return (
     <>
-      <Message icon color='green'>
-        <Icon name='trophy' />
+      <Message icon color="green">
+        <Icon name="trophy" />
         <Message.Content>
           <Message.Header>Final Standings</Message.Header>
-          Thank you to everyone who participated and congratulations to the winners! View the full standings for the Blue division <Link to={'/blue/standings'} className='banner-link'>here</Link> and the Gold division <Link to={'/gold/standings'} className='banner-link'>here</Link>.
-          </Message.Content>
+          Thank you to everyone who participated and congratulations to the winners! View the full standings for the Blue division <Link to={'/blue/standings'} className="banner-link">here</Link> and the Gold division <Link to={'/gold/standings'} className="banner-link">here</Link>.
+        </Message.Content>
       </Message>
       <Countdown />
       <Block size="xs-12">
@@ -71,27 +79,57 @@ const Home = (): React.JSX.Element => {
                 <Table.HeaderCell># of Students</Table.HeaderCell>
               </Table.Row>
             </Table.Header>
-            <Table.Body>
-              {teams
-                .sort(
-                  (t1: TeamType, t2: TeamType) => Date.parse(t2.registration_date) - Date.parse(t1.registration_date)
-                )
-                .map((team: TeamType, index: number) => (
-                  <Table.Row key={`${team.team_name}-${index}`}>
-                    <Table.Cell>{team.team_name}</Table.Cell>
-                    <Table.Cell>
-                      <DivisionLabel division={team.division} />
-                    </Table.Cell>
-                    <Table.Cell>{team.school_name}</Table.Cell>
-                    <Table.Cell>{team.num_of_students}</Table.Cell>
-                  </Table.Row>
-                ))}
-            </Table.Body>
+            {/* Render only paginated teams */}
+            {paginatedTeams.length > 0 ? (
+              <Table.Body>
+                {paginatedTeams
+                  .sort(
+                    (t1: TeamType, t2: TeamType) => Date.parse(t2.registration_date) - Date.parse(t1.registration_date)
+                  )
+                  .map((team: TeamType, index: number) => (
+                    <Table.Row key={`${team.team_name}-${index}`}>
+                      <Table.Cell>{team.team_name}</Table.Cell>
+                      <Table.Cell>
+                        <DivisionLabel division={team.division} />
+                      </Table.Cell>
+                      <Table.Cell>{team.school_name}</Table.Cell>
+                      <Table.Cell>{team.num_of_students}</Table.Cell>
+                    </Table.Row>
+                  ))}
+              </Table.Body>
+            ) : (
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell colSpan="4" textAlign="center">
+                    No teams to display
+                  </Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            )}
           </Table>
         )}
+        <Block size="xs-12">
+          {/* Pagination controls */}
+          <Button
+            onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))} // Go to the previous page
+            disabled={currentPage === 1} // Disable if already on the first page
+          >
+            Previous
+          </Button>
+          <Button
+            onClick={() =>
+              setCurrentPage((prev) =>
+                Math.min(prev + 1, Math.ceil(teams.length / ITEMS_PER_PAGE)) // Go to the next page, preventing going beyond the last page
+              )
+            }
+            disabled={currentPage === Math.ceil(teams.length / ITEMS_PER_PAGE)} // Disable if on the last page
+          >
+            Next
+          </Button>
+        </Block>
       </Block>
     </>
-  )
-}
+  );
+};
 
-export default Home
+export default Home;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -40,9 +40,9 @@ const Home = (): React.JSX.Element => {
     }
   }, [] )
 
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-  const endIndex = startIndex + ITEMS_PER_PAGE;
-  const paginatedTeams = teams.slice(startIndex, endIndex); 
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE
+  const endIndex = startIndex + ITEMS_PER_PAGE
+  const paginatedTeams = teams.slice(startIndex, endIndex) 
 
   return (
     <>
@@ -129,7 +129,7 @@ const Home = (): React.JSX.Element => {
         </Block>
       </Block>
     </>
-  );
-};
+  )
+}
 
-export default Home;
+export default Home

--- a/frontend/src/pages/admin/Clarifications.tsx
+++ b/frontend/src/pages/admin/Clarifications.tsx
@@ -88,7 +88,6 @@ const Clarifications = (): React.JSX.Element => {
     const clarificationsToDelete = clarifications
       .filter((clarification) => clarification.checked)
       .map((clarification) => clarification.cid)
-      //what is this fetch doing?
     await fetch(`${config.API_URL}/clarifications`, {
       method: 'DELETE',
       headers: {

--- a/frontend/src/pages/admin/Clarifications.tsx
+++ b/frontend/src/pages/admin/Clarifications.tsx
@@ -30,6 +30,9 @@ const Clarifications = (): React.JSX.Element => {
     direction: 'ascending'
   })
 
+//Track the current page
+  const[currentPage, setCurrentPage] = useState<number>(1)
+
   const onFilterChange = (event: React.FormEvent<HTMLInputElement>, { checked }: CheckboxProps) =>
     setShowClosed(checked || false)
   /*
@@ -37,9 +40,9 @@ const Clarifications = (): React.JSX.Element => {
   updates the new page of clarifications
   */
 
-  const loadClarifications = async () => {
+  const loadClarifications = async (page: number) => {
     //include page as query, so that API can fetch it.
-    const response = await fetch(`${config.API_URL}/clarifications`, {
+    const response = await fetch(`${config.API_URL}/clarifications?page=${page}`, {
       method: 'GET',
       headers: { Authorization: `Bearer ${localStorage.accessToken}` }
     })
@@ -55,6 +58,10 @@ const Clarifications = (): React.JSX.Element => {
     }
 
     setLoading(false)
+  }
+
+  const handleClarificationsCreated = () => {
+    loadClarifications(currentPage)
   }
 
   const sort = (newColumn: SortKey, clarification_list: ClarificationItem[] = clarifications) => {
@@ -81,6 +88,7 @@ const Clarifications = (): React.JSX.Element => {
     const clarificationsToDelete = clarifications
       .filter((clarification) => clarification.checked)
       .map((clarification) => clarification.cid)
+      //what is this fetch doing?
     await fetch(`${config.API_URL}/clarifications`, {
       method: 'DELETE',
       headers: {
@@ -90,18 +98,20 @@ const Clarifications = (): React.JSX.Element => {
       body: JSON.stringify({ cid: clarificationsToDelete })
     })
     setDeleting(false)
-    loadClarifications()
+    //restore clarifications again when deleting
+    loadClarifications(currentPage)
   }
 
+  //Load users based on current page 
   useEffect(() => {
-    loadClarifications()
-  }, [])
+    loadClarifications(currentPage)
+  }, [currentPage])
 
   if (isLoading) return <PageLoading />
 
   return (
     <>
-      <ClarificationModal trigger={<Button content="Create Clarification" />} />
+      <ClarificationModal trigger={<Button content="Create Clarification" />} onCreate={handleClarificationsCreated} />
       {clarifications.filter((clarification) => clarification.checked).length ? (
         <Button
           content="Delete Selected"
@@ -195,6 +205,12 @@ const Clarifications = (): React.JSX.Element => {
             )}
           </Table.Body>
         </Table>
+
+        <Button content="Previous Page" 
+        onClick={() => setCurrentPage(prev => Math.max(prev -1, 1))} disabled = {currentPage <= 1}/>
+        <Button content="Next Page" 
+        onClick= {() => setCurrentPage( prev => prev + 1 )} />
+      
       </Block>
     </>
   )

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -153,7 +153,8 @@ const Submissions = (): React.JSX.Element => {
       />
       <Button
         content="Next Page"
-        onClick={() => setCurrentPage(prev => prev + 1)} 
+        onClick={() => setCurrentPage(prev => prev + 1)}
+        disabled={submissions.length < 25} //only gives pages with existing entries (edge case bug if page has exactly 25)
       />
 
 

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -146,17 +146,6 @@ const Submissions = (): React.JSX.Element => {
       )}
       <Checkbox toggle label="Show Released" checked={showReleased} onClick={onReleaseChange} />
 
-      <Button
-        content="Previous Page"
-        onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))} 
-        disabled={currentPage <= 1} 
-      />
-      <Button
-        content="Next Page"
-        onClick={() => setCurrentPage(prev => prev + 1)}
-        disabled={submissions.length < 25} //only gives pages with existing entries (edge case bug if page has exactly 25)
-      />
-
 
       <Block size="xs-12" transparent>
         <Menu pointing secondary>
@@ -242,6 +231,17 @@ const Submissions = (): React.JSX.Element => {
           </Table.Body>
         </Table>
       </Block>
+      <Button
+        content="Previous Page"
+        onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))} 
+        disabled={currentPage <= 1} 
+      />
+      <Button
+        content="Next Page"
+        onClick={() => setCurrentPage(prev => prev + 1)}
+        disabled={submissions.length < 25} //only gives pages with existing entries (edge case bug if page has exactly 25)
+      />
+
     </Grid>
   )
 }

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -60,7 +60,7 @@ const Submissions = (): React.JSX.Element => {
   */
   const loadSubmissions = async (page: number) => {
     //include page as query, so that API can fetch it.
-    const response = await fetch(`${config.API_URL}/submissions?page=${currentPage}`, {
+    const response = await fetch(`${config.API_URL}/submissions?page=${page}`, {
       headers: {
         Authorization: `Bearer ${localStorage.accessToken}`,
         'Content-Type': 'application/json'

--- a/frontend/src/pages/admin/submissions/Submissions.tsx
+++ b/frontend/src/pages/admin/submissions/Submissions.tsx
@@ -34,6 +34,8 @@ const Submissions = (): React.JSX.Element => {
     direction: 'ascending'
   })
 
+  const[currentPage, setCurrentPage] = useState<number>(1) //pagination change setup
+
   const sort = (newColumn: SortKey, submission_list: SubmissionItem[] = submissions) => {
     const newDirection = column === newColumn ? 'descending' : 'ascending'
     setSortConfig({ column: newColumn, direction: newDirection })
@@ -47,18 +49,18 @@ const Submissions = (): React.JSX.Element => {
   }
 
   useEffect(() => {
-    loadSubmissions().then(() => setLoading(false))
-    socket?.on('new_submission', () => loadSubmissions())
-    socket?.on('update_submission', () => loadSubmissions())
-  }, [])
+    loadSubmissions(currentPage).then(() => setLoading(false))
+    socket?.on('new_submission', () => loadSubmissions(currentPage))
+    socket?.on('update_submission', () => loadSubmissions(currentPage))
+  }, [currentPage])
 
   /*
   @param page - page to query when paginating
   updates the new page of submissions
   */
-  const loadSubmissions = async () => {
+  const loadSubmissions = async (page: number) => {
     //include page as query, so that API can fetch it.
-    const response = await fetch(`${config.API_URL}/submissions`, {
+    const response = await fetch(`${config.API_URL}/submissions?page=${currentPage}`, {
       headers: {
         Authorization: `Bearer ${localStorage.accessToken}`,
         'Content-Type': 'application/json'
@@ -110,7 +112,7 @@ const Submissions = (): React.JSX.Element => {
           content: 'We deleted the submissions you selected!'
         })
       }
-      loadSubmissions()
+      loadSubmissions(currentPage)
       setDeleting(false)
     }
   }
@@ -143,6 +145,17 @@ const Submissions = (): React.JSX.Element => {
         <></>
       )}
       <Checkbox toggle label="Show Released" checked={showReleased} onClick={onReleaseChange} />
+
+      <Button
+        content="Previous Page"
+        onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))} 
+        disabled={currentPage <= 1} 
+      />
+      <Button
+        content="Next Page"
+        onClick={() => setCurrentPage(prev => prev + 1)} 
+      />
+
 
       <Block size="xs-12" transparent>
         <Menu pointing secondary>

--- a/frontend/src/pages/admin/users/Users.tsx
+++ b/frontend/src/pages/admin/users/Users.tsx
@@ -228,6 +228,7 @@ const Users = (): React.JSX.Element => {
       <Button 
         content="Next Page" 
         onClick={() => setCurrentPage(prev => prev + 1)} // Increment page number
+        disabled={users.length<25} //only gives pages with existing entries (edge case bug if page has exactly 25)
       />
     </Grid>
   )

--- a/frontend/src/pages/admin/users/Users.tsx
+++ b/frontend/src/pages/admin/users/Users.tsx
@@ -21,36 +21,6 @@ type SortConfig = {
   column: SortKey
   direction: 'ascending' | 'descending'
 }
-/*
- <Table sortable>
-        <Table.Header>
-        map shit here -> 
-         {users.map((user: UserItem) => (
-          <Table.Row>
-         {content}
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-         map each row here -> {users.map((user: UserItem) => (
-            <Table.Row key={user.uid} uuid={`${user.uid}`}>
-              <Table.Cell>
-                <input type="checkbox" checked={user.checked} id={user.uid} onChange={handleChange} />
-              </Table.Cell>
-              <Table.Cell className="space-between">
-                <Link to={`/admin/users/${user.uid}`}>{user.username}</Link>
-                {user.disabled && <Label color="red" content="Disabled" />}
-              </Table.Cell>
-              <Table.Cell>{user.role}</Table.Cell>
-              <Table.Cell>
-                <DivisionLabel division={user.division} />
-              </Table.Cell>
-              <Table.Cell>{user.school}</Table.Cell>
-              <Table.Cell>{user.display_name}</Table.Cell>
-            </Table.Row>
-          ))}
-        </Table.Body>
-      </Table>
-*/
 
 const Users = (): React.JSX.Element => {
   usePageTitle("Abacus | Users")
@@ -61,6 +31,10 @@ const Users = (): React.JSX.Element => {
   const [isDeleting, setDeleting] = useState(false)
   const [isImporting, setImporting] = useState(false)
   const [error, setError] = useState<string>()
+  
+  // Added state to track the current page
+  const [currentPage, setCurrentPage] = useState<number>(1) 
+
   const [{ column, direction }, setSortConfig] = useState<SortConfig>({
     column: 'username',
     direction: 'ascending'
@@ -81,18 +55,15 @@ const Users = (): React.JSX.Element => {
     )
   }
 
+  // Changed useEffect to load users based on the current page
   useEffect(() => {
-    loadUsers()
-  }, [])
+    loadUsers(currentPage) // Fetch users based on currentPage
+  }, [currentPage]) // Re-run this effect whenever the currentPage changes
 
-  /*
-  @param page - page to query when paginating
-  updates the new page of users.
-  */
-  const loadUsers = async () => {
+  const loadUsers = async (page: number) => {
     try {
-      //include page as query, so that API can fetch it.
-      const response = await fetch(`${config.API_URL}/users`, {
+      // API now includes the page parameter
+      const response = await fetch(`${config.API_URL}/users?page=${page}`, {
         headers: {
           Authorization: `Bearer ${localStorage.accessToken}`,
           'Content-Type': 'application/json'
@@ -176,18 +147,18 @@ const Users = (): React.JSX.Element => {
 
   const handleChange = ({ target: { id, checked } }: ChangeEvent<HTMLInputElement>) =>
     setUsers(users.map((user) => (user.uid == id ? { ...user, checked } : user)))
+
   const checkAll = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) =>
     setUsers(users.map((user) => ({ ...user, checked })))
 
   const createUserCallback = (response: Response) => {
-    if (response.ok) loadUsers()
+    if (response.ok) loadUsers(currentPage) // Reload users when a new user is created
   }
 
   const deleteSelected = async () => {
-    if (window.confirm('are you sure you want to delete these users?')) {
-      //if the user selects ok, then the code below runs, otherwise nothing occurs
+    if (window.confirm('Are you sure you want to delete these users?')) {
       if (users.filter((u) => u.checked && u.uid == user?.uid).length > 0) {
-        alert('Cannot delete currently logged in user!')
+        alert('Cannot delete the currently logged-in user!')
         return
       }
 
@@ -204,7 +175,7 @@ const Users = (): React.JSX.Element => {
       })
 
       if (response.ok) {
-        loadUsers()
+        loadUsers(currentPage) // Reload users after deletion
         const id = usersToDelete.join()
         window.sendNotification({
           id,
@@ -246,6 +217,17 @@ const Users = (): React.JSX.Element => {
         sort={{ column, direction }}
         onClickHeaderItem={(item: string) => sort(item)}
         onCheckAll={checkAll}
+      />
+      {/* Pagination controls */}
+      
+      <Button
+        content="Previous Page"
+        onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))} // Decrease page number but not below 1
+        disabled={currentPage <= 1} // Disable button if on the first page
+      />
+      <Button 
+        content="Next Page" 
+        onClick={() => setCurrentPage(prev => prev + 1)} // Increment page number
       />
     </Grid>
   )

--- a/frontend/src/pages/judge/Submissions.tsx
+++ b/frontend/src/pages/judge/Submissions.tsx
@@ -25,7 +25,7 @@ const Submissions = (): React.JSX.Element => {
   const socket = useContext(SocketContext)
   const [isLoading, setLoading] = useState(true)
   const [submissions, setSubmissions] = useState<SubmissionItem[]>([])
-  const [isMounted, setMounted] = useState(true)
+ // const [isMounted, setMounted] = useState(true)
   const [isDeleting, setDeleting] = useState(false)
   const [isClaiming, setClaiming] = useState<{ [key: string]: boolean }>({})
   const [showReleased, setShowReleased] = useState(false)

--- a/frontend/src/pages/judge/Submissions.tsx
+++ b/frontend/src/pages/judge/Submissions.tsx
@@ -60,7 +60,6 @@ const Submissions = (): React.JSX.Element => {
   }, [currentPage])
 
   const loadSubmissions = async (page: number) => {
-    console.log('in loadSubmissions: page is ', page)
     const response = await fetch(`${config.API_URL}/submissions?page=${page}?division=${user?.division}`, {
       headers: {
         Authorization: `Bearer ${localStorage.accessToken}`
@@ -190,7 +189,8 @@ const Submissions = (): React.JSX.Element => {
       />
       <Button
         content="Next Page"
-        onClick={() => setCurrentPage(prev => prev + 1)} 
+        onClick={() => setCurrentPage(prev => prev + 1)}
+        disabled={submissions.length < 25} //only gives pages with existing entries (edge case bug if page has exactly 25)
       />
 
       <Table singleLine sortable>

--- a/frontend/src/pages/judge/Submissions.tsx
+++ b/frontend/src/pages/judge/Submissions.tsx
@@ -38,6 +38,8 @@ const Submissions = (): React.JSX.Element => {
     direction: 'ascending'
   })
 
+  const[currentPage, setCurrentPage] = useState<number>(1) //pagination change setup
+
   const sort = (newColumn: SortKey, submission_list: SubmissionItem[] = submissions) => {
     const newDirection = column === newColumn && direction == 'ascending' ? 'descending' : 'ascending'
     setSortConfig({ column: newColumn, direction: newDirection })
@@ -51,21 +53,21 @@ const Submissions = (): React.JSX.Element => {
   }
 
   useEffect(() => {
-    loadSubmissions().then(() => setLoading(false))
-    socket?.on('new_submission', loadSubmissions)
-    socket?.on('update_submission', loadSubmissions)
-    return () => setMounted(false)
-  }, [])
+    loadSubmissions(currentPage).then(() => setLoading(false))
+    socket?.on('new_submission', () => loadSubmissions(currentPage))
+    socket?.on('update_submission', () => loadSubmissions(currentPage))
+    //return () => setMounted(false) //only needed if we don't do pagination
+  }, [currentPage])
 
-  const loadSubmissions = async () => {
-    const response = await fetch(`${config.API_URL}/submissions?division=${user?.division}`, {
+  const loadSubmissions = async (page: number) => {
+    console.log('in loadSubmissions: page is ', page)
+    const response = await fetch(`${config.API_URL}/submissions?page=${page}?division=${user?.division}`, {
       headers: {
         Authorization: `Bearer ${localStorage.accessToken}`
       }
     })
     const submissions = Object.values(await response.json()) as SubmissionItem[]
-
-    if (!isMounted) return
+    //if (!isMounted) return //No longer needed. This is to make sure the same list isn't shown twice. But that's allowed if we paginate
 
     setSubmissions(
       submissions
@@ -97,7 +99,7 @@ const Submissions = (): React.JSX.Element => {
       body: JSON.stringify({ sid: submissionsToDelete })
     })
     if (response.ok) {
-      loadSubmissions()
+      loadSubmissions(currentPage)
     }
     setDeleting(false)
   }
@@ -180,6 +182,16 @@ const Submissions = (): React.JSX.Element => {
         </Button>
       )}
       <Checkbox toggle label="Show Released" checked={showReleased} onClick={onFilterChange} />
+
+      <Button
+        content="Previous Page"
+        onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))} 
+        disabled={currentPage <= 1} 
+      />
+      <Button
+        content="Next Page"
+        onClick={() => setCurrentPage(prev => prev + 1)} 
+      />
 
       <Table singleLine sortable>
         <Table.Header>


### PR DESCRIPTION
# Description

Adds function to split the views of Users, Submissions, and Clarifications sections of the Abacus website into pages, displaying only 25 entries at maximum, rather than all entries in those tables at once, reducing database calls somewhat

Fixes issue #71 and #220

## Type of change

- [x] 💡 New feature
<!-- Non-breaking change which adds functionality -->

- [x] 🧹 Code Cleanup
<!-- General Code Cleanup like removing stale files, comments, etc. -->
  
# How Has This Been Tested?

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
